### PR TITLE
docs: clarify allow-other description

### DIFF
--- a/debian/chd2iso-fuse.1
+++ b/debian/chd2iso-fuse.1
@@ -29,7 +29,7 @@ Mountpoint directory where files will be exposed.
 
 .TP
 \fB--allow-other\fR
-Allow access by other users than the one who mounted.
+Allow access by users other than the one who mounted.
 
 .TP
 \fB--cd-allow-form2\fR


### PR DESCRIPTION
## Summary
- reword allow-other option in man page for clarity

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e7e0d518832e9f7fcf21ac18e005