### PR TITLE
docs: update cache default

### DIFF
--- a/debian/chd2iso-fuse.1
+++ b/debian/chd2iso-fuse.1
@@ -37,7 +37,7 @@ Enable support for CD-ROM XA Form2 tracks.
 
 .TP
 \fB--cache-hunks\fR \fIN\fR
-Number of CHD hunks to cache in memory (default: 8).
+Number of CHD hunks to cache in memory (default: 256).
 
 .TP
 \fB--cache-bytes\fR \fIBYTES\fR


### PR DESCRIPTION
## Summary
- update cache-hunks default from 8 to 256 in man page

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e81d1de8832e9d52b82673d56cad