### PR TITLE
chore(dependabot): retarget updates to develop branch for git-flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,31 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Routine dependency updates → develop
+  - package-ecosystem: cargo
+    directory: "/"
     schedule:
-      interval: "daily"
+      interval: daily
+    target-branch: develop
+    labels: [deps, cargo]
+    open-pull-requests-limit: 10
+    groups:
+      routine:
+        update-types: [minor, patch]
+
+  # GitHub Actions updates → develop
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: develop
+    labels: [deps, ci]
+    open-pull-requests-limit: 10
+
+  # Security-only updates → main
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: main
+    security-updates-only: true
+    labels: [security, hotfix]


### PR DESCRIPTION
Ensure routine Cargo and GitHub Actions updates land on `develop`. Add security-only rule targeting `main` for critical hotfixes.