### PR TITLE
Feature/release on tag

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -53,6 +53,7 @@ jobs:
           echo "lane=$lane" >> "$GITHUB_OUTPUT"
 
   build:
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     name: Build & Test
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -9,17 +9,93 @@ permissions:
 
 jobs:
   build:
+    name: Build (tag)
     uses: ./.github/workflows/_build.yml
     with:
       lane: main
     secrets: inherit
 
-  release:
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
     needs: build
-    uses: ./.github/workflows/_release.yml
-    permissions:
-      contents: write
-    with:
-      lane: main
-      apt_enabled: false  # flip later
-    secrets: inherit
+    steps:
+      - name: Debug event info
+        run: |
+          echo "event_name=${GITHUB_EVENT_NAME}"
+          echo "ref=${GITHUB_REF}"
+          echo "ref_name=${GITHUB_REF_NAME}"
+
+      - name: Download build artifacts from previous job
+        uses: actions/download-artifact@v4
+        with:
+          # Download all artifacts produced by _build.yml (pattern works with v4)
+          pattern: chd2iso-fuse-*
+          path: ./artifacts
+          merge-multiple: true
+
+      - name: List downloaded artifacts & guard
+        shell: bash
+        run: |
+          echo "Artifacts under ./artifacts:"
+          find ./artifacts -type f -maxdepth 2 -printf '%P\n' | sort || true
+          shopt -s nullglob
+          deb=(artifacts/*.deb); bi=(artifacts/*.buildinfo); ch=(artifacts/*.changes)
+          if [ ${#deb[@]} -eq 0 ] && [ ${#bi[@]} -eq 0 ] && [ ${#ch[@]} -eq 0 ]; then
+            echo "No .deb/.buildinfo/.changes files found after download."
+            exit 1
+          fi
+
+      - name: Ensure RELEASE_NOTES.md
+        shell: bash
+        run: |
+          if [ -f artifacts/RELEASE_NOTES.md ]; then
+            cp artifacts/RELEASE_NOTES.md RELEASE_NOTES.md
+          elif [ -f artifacts/CHANGELOG.md ]; then
+            cp artifacts/CHANGELOG.md RELEASE_NOTES.md
+          else
+            echo "(no release notes provided)" > RELEASE_NOTES.md
+          fi
+          sed -n '1,120p' RELEASE_NOTES.md || true
+
+      - name: Assemble release asset list (root files)
+        id: assets
+        shell: bash
+        run: |
+          set -e
+          shopt -s nullglob
+          files=()
+          # Flatten to repo root for the upload action
+          for f in artifacts/*.deb artifacts/*.buildinfo artifacts/*.changes artifacts/SHA256SUMS artifacts/SHA256SUMS.asc; do
+            [ -e "$f" ] || continue
+            cp "$f" .
+            files+=("$(basename "$f")")
+          done
+          echo "Will upload:"
+          printf '  - %s\n' "${files[@]}"
+          {
+            echo 'ASSET_FILES<<EOF'
+            printf '%s\n' "${files[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Create draft release & upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: chd2iso-fuse ${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md
+          generate_release_notes: false
+          draft: true
+          fail_on_unmatched_files: false
+          files: ${{ env.ASSET_FILES }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release (flip draft -> published)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          draft: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,25 @@
+name: Release on tag
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build.yml
+    with:
+      lane: main
+    secrets: inherit
+
+  release:
+    needs: build
+    uses: ./.github/workflows/_release.yml
+    permissions:
+      contents: write
+    with:
+      lane: main
+      apt_enabled: false  # flip later
+    secrets: inherit


### PR DESCRIPTION
ci(release): add tag-driven entrypoint using reusable build/release

New release-on-tag.yml triggers on v* tags, builds via _build.yml, and
publishes a GitHub Release with downloaded artifacts and notes. This
replaces the tag path from the legacy ci.yml.