### PR TITLE
ci(release): add version/changelog guard for release/* and hotfix/*

### DIFF
--- a/.github/workflows/_verify-release.yml
+++ b/.github/workflows/_verify-release.yml
@@ -1,0 +1,107 @@
+name: Reusable — Verify release lane versions
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify versions (Cargo.toml / debian / binary)
+    runs-on: ubuntu-latest
+    container:
+      image: debian:trixie
+      options: --init
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Install minimal deps
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libfuse3-dev fuse3 \
+            rust-all rust-clippy rustfmt \
+            debhelper devscripts dh-cargo dpkg-dev
+
+      - name: Read Cargo.toml version
+        id: cargo
+        shell: bash
+        run: |
+          set -euo pipefail
+          CARGO_VER="$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' Cargo.toml | head -n1)"
+          if [[ -z "${CARGO_VER}" ]]; then
+            echo "Failed to read version from Cargo.toml"; exit 1
+          fi
+          echo "version=${CARGO_VER}" >> "$GITHUB_OUTPUT"
+          echo "Cargo.toml version: ${CARGO_VER}"
+
+          # Disallow -dev suffix on release/hotfix
+          if [[ "${CARGO_VER}" == *-dev* ]]; then
+            echo "ERROR: Cargo.toml has a -dev suffix on a release lane: ${CARGO_VER}"
+            exit 1
+          fi
+
+      - name: Read Debian upstream version
+        id: deb
+        shell: bash
+        run: |
+          set -euo pipefail
+          # dpkg-parsechangelog is provided by dpkg-dev
+          DEB_FULL="$(dpkg-parsechangelog -SVersion || true)"
+          if [[ -z "${DEB_FULL}" ]]; then
+            echo "ERROR: Could not parse debian/changelog. Did you update it for this release lane?"; exit 1
+          fi
+          # upstream is part before the first dash
+          UPSTREAM="${DEB_FULL%%-*}"
+          echo "full=${DEB_FULL}"     >> "$GITHUB_OUTPUT"
+          echo "upstream=${UPSTREAM}" >> "$GITHUB_OUTPUT"
+          echo "Debian version (full): ${DEB_FULL}"
+          echo "Debian upstream:       ${UPSTREAM}"
+
+      - name: Compare Cargo vs Debian upstream (supports RC mapping)
+        env:
+          CARGO_VER: ${{ steps.cargo.outputs.version }}
+          DEB_UP:    ${{ steps.deb.outputs.upstream }}
+        run: |
+          set -euo pipefail
+          # Map Cargo RC (X.Y.Z-rcN) to Debian upstream (X.Y.Z~rcN)
+          if [[ "${CARGO_VER}" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-rc([0-9]+)$ ]]; then
+            EXPECT="${BASH_REMATCH[1]}~rc${BASH_REMATCH[2]}"
+          else
+            EXPECT="${CARGO_VER}"
+          fi
+
+          echo "Expect Debian upstream: ${EXPECT}"
+          if [[ "${DEB_UP}" != "${EXPECT}" ]]; then
+            echo "ERROR: debian/changelog upstream (${DEB_UP}) != expected (${EXPECT})"
+            exit 1
+          fi
+
+      - name: Build release binary (for version check)
+        run: cargo build --release --locked
+
+      - name: Verify binary --version matches Cargo.toml
+        env:
+          CARGO_VER: ${{ steps.cargo.outputs.version }}
+        run: |
+          set -euo pipefail
+          BIN="./target/release/chd2iso-fuse"
+          test -x "$BIN" || { echo "Binary not found at ${BIN}"; exit 1; }
+          BIN_VER="$("$BIN" --version | awk '{print $2}')"
+          echo "Binary --version: ${BIN_VER}"
+          if [[ "${BIN_VER}" != "${CARGO_VER}" ]]; then
+            echo "ERROR: Binary version (${BIN_VER}) != Cargo.toml version (${CARGO_VER})"
+            exit 1
+          fi
+
+      - name: Summary
+        run: |
+          echo "✅ Version checks passed:"
+          echo " - Cargo.toml:       ${{ steps.cargo.outputs.version }}"
+          echo " - Debian upstream:  ${{ steps.deb.outputs.upstream }}"
+          echo " - Binary --version: $("$PWD/target/release/chd2iso-fuse" --version | awk '{print $2}')"

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -68,6 +68,13 @@ jobs:
           [[ "$ref" == release/* ]] && lane="release"
           [[ "$ref" == hotfix/*  ]] && lane="hotfix"
           echo "lane=$lane" >> "$GITHUB_OUTPUT"
+          
+  verify-release:
+    if: ${{ startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/') }}
+    name: Verify release lane
+    needs: decide
+    uses: ./.github/workflows/_verify-release.yml
+    secrets: inherit
 
   build:
     if: ${{ needs.dedupe.outputs.should_skip != 'true' && !startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
- New _verify-release.yml checks:
  * Cargo.toml has no -dev suffix
  * Debian upstream matches Cargo.toml (supports X.Y.Z-rcN ↔ X.Y.Z~rcN)
  * Built binary --version equals Cargo.toml
- Wired from ci-router on release/* and hotfix/* lanes