### PR TITLE
ci(publish): add stub _publish-apt.yml and wire via environments (gated)

### DIFF
--- a/.github/workflows/_publish-apt.yml
+++ b/.github/workflows/_publish-apt.yml
@@ -1,0 +1,40 @@
+name: Reusable — Publish APT (stub)
+
+on:
+  workflow_call:
+    inputs:
+      channel:
+        description: "Target channel: unstable|candidate|stable"
+        type: string
+        required: true
+      suite:
+        description: "Debian suite (e.g., trixie)"
+        type: string
+        default: "trixie"
+      component:
+        description: "Component (e.g., main)"
+        type: string
+        default: "main"
+      arch:
+        description: "Architecture"
+        type: string
+        default: "amd64"
+    secrets: {}
+
+permissions:
+  contents: read
+
+jobs:
+  stub:
+    name: Stub publish to ${{ inputs.channel }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain gating
+        run: |
+          echo "🔒 APT publishing is currently gated (no-op)."
+          echo "Requested channel: ${{ inputs.channel }}"
+          echo "Suite:             ${{ inputs.suite }}"
+          echo "Component:         ${{ inputs.component }}"
+          echo "Arch:              ${{ inputs.arch }}"
+          echo
+          echo "When ready to go live, implement reprepro/aptly steps here."

--- a/.github/workflows/_publish-apt.yml
+++ b/.github/workflows/_publish-apt.yml
@@ -28,6 +28,8 @@ jobs:
   stub:
     name: Stub publish to ${{ inputs.channel }}
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.channel }}   # approvals per channel, if configured
     steps:
       - name: Explain gating
         run: |

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -63,8 +63,6 @@ jobs:
     name: Publish to APT (gated)
     needs: prepare-release
     if: ${{ inputs.apt_enabled && needs.prepare-release.outputs.channel != 'none' }}
-    environment:
-      name: ${{ needs.prepare-release.outputs.channel }}   # unstable | candidate | stable
     permissions:
       contents: read
     uses: ./.github/workflows/_publish-apt.yml

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,10 +1,11 @@
 name: Reusable — Release lane
+
 on:
   workflow_call:
     inputs:
-      lane: { type: string, required: true }
-      nightly: { type: boolean, default: false }
-      apt_enabled: { type: boolean, default: false }
+      lane:       { type: string,  required: true }
+      nightly:    { type: boolean, default: false }
+      apt_enabled:{ type: boolean, default: false }
     secrets: {}
 
 permissions:
@@ -12,45 +13,72 @@ permissions:
 
 jobs:
   prepare-release:
-    name: Prepare release (no-op for now)
+    name: Prepare release (decide channel)
     runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.ch.outputs.channel }}
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
       - name: Determine channel
         id: ch
+        shell: bash
         run: |
+          set -euo pipefail
           lane="${{ inputs.lane }}"
+          nightly="${{ inputs.nightly }}"
           channel="none"
           case "$lane" in
-            develop)  channel="${{ inputs.nightly && 'unstable' || 'none' }}" ;;
+            develop)
+              if [[ "$nightly" == "true" ]]; then
+                channel="unstable"
+              else
+                channel="none"
+              fi
+              ;;
             release*) channel="candidate" ;;
             hotfix*)  channel="candidate" ;;
             main)     channel="stable" ;;
+            *)        channel="none" ;;
           esac
           echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "Resolved channel: $channel"
 
       - name: Summary
+        shell: bash
         run: |
-          echo "Lane: ${{ inputs.lane }}"
-          echo "Nightly: ${{ inputs.nightly }}"
-          echo "Channel: ${{ steps.ch.outputs.channel }}"
-          echo "APT enabled: ${{ inputs.apt_enabled }}"
+          echo "Lane:     ${{ inputs.lane }}"
+          echo "Nightly:  ${{ inputs.nightly }}"
+          echo "Channel:  ${{ steps.ch.outputs.channel }}"
+          echo "APT:      ${{ inputs.apt_enabled }}"
 
   publish-apt:
-    needs: prepare-release
-    if: ${{ inputs.apt_enabled && steps.ch.outputs.channel != 'none' }}
     name: Publish to APT (gated)
+    needs: prepare-release
+    if: ${{ inputs.apt_enabled && needs.prepare-release.outputs.channel != 'none' }}
     # Route to an environment that matches the channel (enforces approvals if configured)
     environment:
-      name: ${{ steps.ch.outputs.channel }}   # unstable | candidate | stable
+      name: ${{ needs.prepare-release.outputs.channel }}   # unstable | candidate | stable
     permissions:
       contents: read
+    # Reusable workflow call — do not add runs-on/steps here
     uses: ./.github/workflows/_publish-apt.yml
     with:
-      channel:   ${{ steps.ch.outputs.channel }}
+      channel:   ${{ needs.prepare-release.outputs.channel }}
       suite:     trixie
       component: main
       arch:      amd64
     secrets: inherit
+
+  publish-stub:
+    name: Publish stub
+    needs: prepare-release
+    if: ${{ !inputs.apt_enabled || needs.prepare-release.outputs.channel == 'none' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op publish
+        shell: bash
+        run: |
+          echo "No publishing required."
+          echo "channel='${{ needs.prepare-release.outputs.channel }}', apt_enabled='${{ inputs.apt_enabled }}'"

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -38,11 +38,19 @@ jobs:
           echo "Channel: ${{ steps.ch.outputs.channel }}"
           echo "APT enabled: ${{ inputs.apt_enabled }}"
 
-  # Placeholder for later:
-  # publish-apt:
-  #   needs: prepare-release
-  #   if: ${{ inputs.apt_enabled && steps.ch.outputs.channel != 'none' }}
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: (Future) Publish to APT
-  #       run: echo "Publishing to ${{ steps.ch.outputs.channel }} is gated off."
+  publish-apt:
+    needs: prepare-release
+    if: ${{ inputs.apt_enabled && steps.ch.outputs.channel != 'none' }}
+    name: Publish to APT (gated)
+    # Route to an environment that matches the channel (enforces approvals if configured)
+    environment:
+      name: ${{ steps.ch.outputs.channel }}   # unstable | candidate | stable
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_publish-apt.yml
+    with:
+      channel:   ${{ steps.ch.outputs.channel }}
+      suite:     trixie
+      component: main
+      arch:      amd64
+    secrets: inherit

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,10 +1,17 @@
 name: Reusable — Release lane
+
 on:
   workflow_call:
     inputs:
-      lane:       { type: string,  required: true }
-      nightly:    { type: boolean, default: false }
-      apt_enabled:{ type: boolean, default: false }
+      lane:
+        type: string
+        required: true
+      nightly:
+        type: boolean
+        default: false
+      apt_enabled:
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # for GitHub Releases later
@@ -17,7 +24,8 @@ jobs:
       channel: ${{ steps.ch.outputs.channel }}
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
       - name: Determine channel
         id: ch
@@ -55,12 +63,10 @@ jobs:
     name: Publish to APT (gated)
     needs: prepare-release
     if: ${{ inputs.apt_enabled && needs.prepare-release.outputs.channel != 'none' }}
-    # Route to an environment that matches the channel (enforces approvals if configured)
     environment:
       name: ${{ needs.prepare-release.outputs.channel }}   # unstable | candidate | stable
     permissions:
       contents: read
-    # Reusable workflow call — do not add runs-on/steps here
     uses: ./.github/workflows/_publish-apt.yml
     with:
       channel:   ${{ needs.prepare-release.outputs.channel }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -1,12 +1,10 @@
 name: Reusable — Release lane
-
 on:
   workflow_call:
     inputs:
       lane:       { type: string,  required: true }
       nightly:    { type: boolean, default: false }
       apt_enabled:{ type: boolean, default: false }
-    secrets: {}
 
 permissions:
   contents: write   # for GitHub Releases later

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -21,6 +21,9 @@ on:
       - "debian/**"
       - ".github/workflows/**"
       - "Makefile"
+  # Nightly runs (e.g., weekdays 08:15 London) — adjust to taste
+  schedule:
+    - cron: "15 8 * * 1-5"
   workflow_dispatch:
 
 permissions:
@@ -55,10 +58,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       lane: ${{ steps.which.outputs.lane }}
+      nightly: ${{ steps.which.outputs.nightly }}
     steps:
       - id: which
         shell: bash
         run: |
+          set -euo pipefail
           ref="${GITHUB_REF_NAME}"
           lane="feature"
           case "$ref" in
@@ -67,8 +72,16 @@ jobs:
           esac
           [[ "$ref" == release/* ]] && lane="release"
           [[ "$ref" == hotfix/*  ]] && lane="hotfix"
-          echo "lane=$lane" >> "$GITHUB_OUTPUT"
-          
+
+          # Nightly rule: scheduled runs on develop => nightly=true
+          nightly="false"
+          if [[ "${{ github.event_name }}" == "schedule" && "$lane" == "develop" ]]; then
+            nightly="true"
+          fi
+
+          echo "lane=$lane"       >> "$GITHUB_OUTPUT"
+          echo "nightly=$nightly" >> "$GITHUB_OUTPUT"
+
   verify-release:
     if: ${{ startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/') }}
     name: Verify release lane
@@ -93,6 +106,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/_release.yml
     with:
-      lane: ${{ needs.decide.outputs.lane }}
-      apt_enabled: false   # flip to true per environment when APT is ready
+      lane:        ${{ needs.decide.outputs.lane }}
+      nightly:     ${{ needs.decide.outputs.nightly }}
+      apt_enabled: false   # flip to true when APT publishing is ready
     secrets: inherit


### PR DESCRIPTION
- Introduces reusable _publish-apt.yml (currently a no-op stub).
- Wires publishing from _release.yml with channel → environment mapping:
  * develop/nightly → unstable
  * release/* & hotfix/* → candidate
  * tags on main → stable
- APT remains disabled via apt_enabled=false in the router; flipping it
  per-environment will enable real publishing later.
