### PR TITLE
ci(build): avoid double compile; rely on dh-cargo in Debian build

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -78,10 +78,11 @@ jobs:
       - name: Rust tests
         run: cargo test --workspace --locked --all-features
 
-      - name: Build release binary
-        run: cargo build --release --locked
-
       - name: Debian build
+        env:
+          DEB_BUILD_OPTIONS: nocheck
+          RUSTC_WRAPPER: ${{ env.RUSTC_WRAPPER }}   # keep sccache wrapping for dh-cargo
+          SCCACHE_DIR: ${{ env.SCCACHE_DIR }}
         run: |
           dpkg-buildpackage -us -uc -b
           mkdir -p artifacts


### PR DESCRIPTION
- Remove standalone `cargo build --release` step (wasn’t reused by dh-cargo).
- Set DEB_BUILD_OPTIONS=nocheck so tests don’t run twice (we already run `cargo test` earlier).
- Keep sccache env so the Debian build is cached/wrapped.