### PR TITLE
ci(ruleset-compat): make CodeQL and cargo-audit no-op on non-code PRs

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -49,7 +49,8 @@ jobs:
           cancel_others: 'true'
           skip_after_successful_duplicate: 'true'
           concurrent_skipping: 'same_content'
-          do_not_skip: '["workflow_dispatch", "schedule"]'
+          # IMPORTANT: don't skip PRs (we need the PR checks to report success)
+          do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   decide:
     if: ${{ needs.dedupe.outputs.should_skip != 'true' }}

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -37,6 +37,7 @@ concurrency:
 
 jobs:
   # Skip/cancel duplicates between push and pull_request for the same commit/content
+jobs:
   dedupe:
     name: De-duplicate cross-event runs
     runs-on: ubuntu-latest
@@ -49,7 +50,7 @@ jobs:
           cancel_others: 'true'
           skip_after_successful_duplicate: 'true'
           concurrent_skipping: 'same_content'
-          # IMPORTANT: don't skip PRs (we need the PR checks to report success)
+          # IMPORTANT: PR runs must not be skipped, or required checks never report on the PR
           do_not_skip: '["pull_request", "workflow_dispatch", "schedule"]'
 
   decide:

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -35,7 +35,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
   # Skip/cancel duplicates between push and pull_request for the same commit/content
 jobs:
   dedupe:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with: { fetch-depth: 0 }
 
-      # NEW: detect whether Rust/package files changed
       - name: Determine if Rust/package files changed
         id: paths
         uses: dorny/paths-filter@v3
@@ -42,12 +41,10 @@ jobs:
               - 'build.rs'
               - 'debian/**'
 
-      # Quick path: acknowledge non-code PRs and exit fast
       - name: No-op (non-code PR)
         if: ${{ steps.paths.outputs.rust != 'true' && github.event_name == 'pull_request' }}
         run: echo "No Rust/package changes in this PR; skipping heavy CodeQL steps."
 
-      # Heavy steps only when code changed, or on scheduled/manual runs
       - name: Install system deps
         if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         run: |
@@ -60,7 +57,7 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Init CodeQL
+      - name: Initialize CodeQL
         if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,24 +3,10 @@ name: CodeQL (Rust)
 on:
   push:
     branches: [ develop, main ]
-    paths:
-      - "src/**"
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "build.rs"
-      - "debian/**"         # include if packaging changes should be analyzed
   pull_request:
     branches: [ develop, main ]
-    paths:
-      - "src/**"
-      - "**/*.rs"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "build.rs"
-      - "debian/**"
   schedule:
-    - cron: "30 3 * * 1"   # weekly scan
+    - cron: "30 3 * * 1"
   workflow_dispatch:
 
 permissions:
@@ -40,31 +26,54 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        with: { fetch-depth: 0 }
 
+      # NEW: detect whether Rust/package files changed
+      - name: Determine if Rust/package files changed
+        id: paths
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rust:
+              - 'src/**'
+              - '**/*.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'build.rs'
+              - 'debian/**'
+
+      # Quick path: acknowledge non-code PRs and exit fast
+      - name: No-op (non-code PR)
+        if: ${{ steps.paths.outputs.rust != 'true' && github.event_name == 'pull_request' }}
+        run: echo "No Rust/package changes in this PR; skipping heavy CodeQL steps."
+
+      # Heavy steps only when code changed, or on scheduled/manual runs
       - name: Install system deps
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends pkg-config libfuse3-dev
 
       - name: Setup Rust
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
       - name: Init CodeQL
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         uses: github/codeql-action/init@v3
         with:
           languages: rust
           queries: +security-and-quality
 
       - name: Build (all features & targets)
-        env:
-          CARGO_TERM_COLOR: always
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
+        env: { CARGO_TERM_COLOR: always }
         run: |
           cargo fetch --locked
           cargo build --locked --all-targets --all-features
 
       - name: Analyze
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -29,43 +29,48 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Determine if Rust/package files changed
+        id: paths
+        uses: dorny/paths-filter@v3
         with:
-          fetch-depth: 0
+          filters: |
+            rust:
+              - 'src/**'
+              - '**/*.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'build.rs'
+              - 'debian/**'
+
+      - name: No-op (non-code PR)
+        if: ${{ steps.paths.outputs.rust != 'true' && github.event_name == 'pull_request' }}
+        run: echo "No Rust/package changes in this PR; skipping cargo-audit."
 
       - name: Install Rust (stable)
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
 
-      # Cache the cargo-audit binary; key includes the resolved version so upgrades invalidate cache
-      - name: Cache cargo-audit binary
-        id: cache_audit
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/bin/cargo-audit
-          key: cargo-audit-bin-${{ runner.os }}-latest
-
       - name: Install latest cargo-audit
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
           if ! command -v cargo-audit >/dev/null 2>&1; then
             cargo install cargo-audit --locked
           fi
-          cargo -V
-          rustc -V
           cargo audit --version
 
-      # Ensure a lockfile exists (needed by cargo-audit)
       - name: Ensure Cargo.lock exists
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         run: |
           set -euo pipefail
-          if [ ! -f Cargo.lock ]; then
-            echo "Cargo.lock not found; generating…"
-            cargo generate-lockfile
-          fi
+          [ -f Cargo.lock ] || cargo generate-lockfile
 
-      # Run audit (advisory DB auto-updates unless --no-fetch is given)
       - name: Run cargo-audit
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -77,5 +82,4 @@ jobs:
               [[ -n "$id_trimmed" ]] && args+=( --ignore "$id_trimmed" )
             done
           fi
-          echo "Running: cargo audit ${args[*]}"
           cargo audit "${args[@]}"


### PR DESCRIPTION
- Remove path filters on triggers so required checks always appear on PRs.
- Use dorny/paths-filter to detect Rust/package changes and skip heavy steps when a PR only touches non-code (e.g., issue templates, docs).
- Keeps scheduled scans intact and full analysis on real code changes.