### PR TITLE
debian/watch: switch to git refs backend for robustness

### DIFF
--- a/debian/watch
+++ b/debian/watch
@@ -1,3 +1,9 @@
 version=4
-opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/chd2iso-fuse-$1\.tar\.gz/ \
-  https://github.com/lloydsmart/chd2iso-fuse/tags .*/archive/v?(\d[\d\.]*)\.tar\.gz
+# Use the git backend so uscan inspects remote refs instead of scraping HTML.
+# @ANY_VERSION@ matches things like 0.2.6 (no leading "v" required thanks to v? in the pattern).
+opts=mode=git,\
+    dversionmangle=s/^[0-9]+://,\
+    filenamemangle=s%.*v?(@ANY_VERSION@)%chd2iso-fuse-$1.tar.gz% \
+  https://github.com/lloydsmart/chd2iso-fuse.git \
+  refs/tags/v?@ANY_VERSION@ \
+  debian uupdate


### PR DESCRIPTION
# PR: Switch `debian/watch` to git-refs backend for uscan

## Summary
This PR updates the `debian/watch` file for **chd2iso-fuse** to use the `git refs` backend instead of scraping GitHub tag pages.  

By switching to `mode=git`, we eliminate the dependency on GitHub’s HTML layout and ensure `uscan` can always discover new upstream versions directly from the repository’s tags.

## Changes
- Replace HTML scraping of `/archive/refs/tags/` tarballs with:
  - `mode=git` backend, querying `refs/tags/` directly  
  - `filenamemangle` to normalise tarball names (`chd2iso-fuse-$version.tar.gz`)  
  - `dversionmangle` to strip epochs if ever added  
  - `debian uupdate` integration for smoother packaging updates  

## Benefits
- **Robustness**: no longer breaks if GitHub changes its tag pages  
- **Future-proof**: directly tied to upstream git tags  
- **Consistency**: orig tarballs are generated reliably via `git archive`  
- **Ease of maintenance**: less watch-file churn in future  

## Next steps
With this change merged:
- CI `uscan` checks will be stable and won’t fail on GitHub URL layout changes  
- New upstream tags will be automatically detected and integrated into the Debian packaging workflow  
