### PR TITLE
fix(ci/release): lock release title to resolved tag to prevent “-1” drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ permissions:
   security-events: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  # Avoid collisions: for workflow_dispatch use the provided tag; for push use github.ref
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
   cancel-in-progress: false
 
 defaults:
@@ -22,8 +23,31 @@ defaults:
     shell: bash
 
 jobs:
+  resolve_tag:
+    name: Resolve tag for this run
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.out.outputs.tag }}
+    steps:
+      - id: out
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ -n "${{ inputs.tag }}" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            # event is push on a tag
+            tag="${GITHUB_REF_NAME}"
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::Unable to resolve tag."
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Resolved TAG=$tag"
+
   guard_tag_on_main:
     name: Guard - tag must be on main
+    needs: [resolve_tag]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout full history
@@ -35,18 +59,14 @@ jobs:
         run: |
           set -euo pipefail
           echo "event_name=${GITHUB_EVENT_NAME}"
-          echo "event.ref_name=${GITHUB_REF_NAME}"
+          echo "resolved_tag=${{ needs.resolve_tag.outputs.tag }}"
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           echo "origin/main -> $(git rev-parse refs/remotes/origin/main)"
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "input tag     -> ${{ inputs.tag }}"
-          fi
 
       - name: Verify tag commit is reachable from origin main
         run: |
           set -euo pipefail
-          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
-          if [ -z "$TAG" ]; then echo "::error::No tag resolved."; exit 1; fi
+          TAG="${{ needs.resolve_tag.outputs.tag }}"
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           TAG_SHA="$(git rev-parse "${TAG}^{commit}")"
           echo "Tag ${TAG} -> ${TAG_SHA}"
@@ -74,7 +94,7 @@ jobs:
 
   publish_release:
     name: Publish GitHub Release
-    needs: [build, verify_versions]
+    needs: [build, verify_versions, resolve_tag]
     runs-on: ubuntu-latest
     steps:
       - name: Preflight check (identity variables present)
@@ -87,7 +107,7 @@ jobs:
           if [ "${HAS_AUTHOR_EMAIL}" != "true" ]; then echo "::warning::Variable GIT_AUTHOR_EMAIL is not set (will use default)."; fi
 
       - name: Debug tag
-        run: echo "tag=${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+        run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
 
       - name: Configure git identity (from Actions Variables)
         run: |
@@ -167,8 +187,8 @@ jobs:
       - name: Create draft release and upload
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
-          name: "chd2iso-fuse ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          tag_name: ${{ needs.resolve_tag.outputs.tag }}
+          name: "chd2iso-fuse ${{ needs.resolve_tag.outputs.tag }}"
           body_path: "RELEASE_NOTES.md"
           generate_release_notes: false
           draft: true
@@ -180,10 +200,33 @@ jobs:
       - name: Publish draft
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          tag_name: ${{ needs.resolve_tag.outputs.tag }}
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reconcile release title with tag (safety net)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = `${{ needs.resolve_tag.outputs.tag }}`;
+            try {
+              const res = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner, repo: context.repo.repo, tag
+              });
+              const desired = `chd2iso-fuse ${tag}`;
+              if (res.data.name !== desired) {
+                await github.rest.repos.updateRelease({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  release_id: res.data.id, name: desired
+                });
+                core.info(`Updated release title to '${desired}'`);
+              } else {
+                core.info('Release title already correct.');
+              }
+            } catch (e) {
+              core.setFailed(`Failed to reconcile title: ${e.message}`);
+            }
 
   release_lane:
     name: Release lane and optional APT


### PR DESCRIPTION
- Add resolve_tag job to compute a single TAG for both push and workflow_dispatch
- Use TAG for guard, gh-release tag_name, and release title
- Adjust concurrency group to deconflict dispatch vs push runs
- Add final reconciliation step to force title to “chd2iso-fuse <TAG>”
- Fixes #102 