### PR TITLE
fix(ci/release): always attach artifacts and changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -106,9 +106,6 @@ jobs:
           if [ "${HAS_AUTHOR_NAME}" != "true" ]; then echo "::warning::Variable GIT_AUTHOR_NAME is not set (will use default)."; fi
           if [ "${HAS_AUTHOR_EMAIL}" != "true" ]; then echo "::warning::Variable GIT_AUTHOR_EMAIL is not set (will use default)."; fi
 
-      - name: Debug tag
-        run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
-
       - name: Configure git identity (from Actions Variables)
         run: |
           set -euo pipefail
@@ -120,34 +117,68 @@ jobs:
           git config --global user.email "${EMAIL}"
           echo "Using git identity: ${NAME} <${EMAIL}>"
 
-      - name: Download build artifacts
+      - name: Debug tag
+        run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
+
+      - name: Download build artifacts (all)
         uses: actions/download-artifact@v4
         with:
-          path: "artifacts"
+          pattern: '*'
+          path: artifacts
           merge-multiple: true
 
       - name: Guard artifacts exist
         run: |
           set -euo pipefail
           shopt -s nullglob
-          deb=(artifacts/*.deb)
-          bi=(artifacts/*.buildinfo)
-          ch=(artifacts/*.changes)
-          if [ ${#deb[@]} -eq 0 ] && [ ${#bi[@]} -eq 0 ] && [ ${#ch[@]} -eq 0 ]; then
-            echo "No artifacts found in ./artifacts"
+          files=(artifacts/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No artifacts found in ./artifacts"
             exit 1
           fi
+          echo "Artifacts downloaded:"
           find "artifacts" -maxdepth 2 -type f -printf '%P\n' | sort || true
 
-      - name: Ensure RELEASE_NOTES.md
+      # If build didn't provide notes, generate with git-cliff (tag range)
+      - name: Checkout full history (for changelog generation)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure RELEASE_NOTES.md (prefer provided; otherwise generate via git-cliff)
+        id: notes
         run: |
           set -euo pipefail
           if [ -f artifacts/RELEASE_NOTES.md ]; then
             cp artifacts/RELEASE_NOTES.md RELEASE_NOTES.md
+            echo "source=artifact" >> "$GITHUB_OUTPUT"
           elif [ -f artifacts/CHANGELOG.md ]; then
             cp artifacts/CHANGELOG.md RELEASE_NOTES.md
+            echo "source=artifact" >> "$GITHUB_OUTPUT"
           else
-            echo "(no release notes provided)" > RELEASE_NOTES.md
+            echo "No notes artifact found; generating with git-cliff…"
+            echo "source=cliff" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install git-cliff
+        if: steps.notes.outputs.source == 'cliff'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Generate release notes with git-cliff
+        if: steps.notes.outputs.source == 'cliff'
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.resolve_tag.outputs.tag }}"
+          # Find previous tag chronologically older than TAG
+          PREV_TAG="$(git for-each-ref --sort=-creatordate --format='%(refname:short)' refs/tags | awk -v t="$TAG" '$0!=t{seen=seen} $0==t{exit} {print}' | head -n1 || true)"
+          if [[ -n "${PREV_TAG}" ]]; then
+            echo "Generating notes for range ${PREV_TAG}..${TAG}"
+            git-cliff --tag "${TAG}" --range "${PREV_TAG}..${TAG}" -o RELEASE_NOTES.md
+          else
+            echo "No previous tag found; generating notes up to ${TAG}"
+            git-cliff --tag "${TAG}" -o RELEASE_NOTES.md
           fi
           sed -n '1,120p' RELEASE_NOTES.md || true
 
@@ -173,8 +204,9 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           files=()
-          for f in artifacts/*.deb artifacts/*.buildinfo artifacts/*.changes artifacts/SHA256SUMS artifacts/SHA256SUMS.asc; do
+          for f in artifacts/*; do
             [ -e "$f" ] || continue
+            # Copy alongside RELEASE_NOTES.md for simple upload globs
             cp -v "$f" .
             files+=("$(basename "$f")")
           done
@@ -183,6 +215,7 @@ jobs:
             printf '%s\n' "${files[@]}"
             echo 'EOF'
           } >> "$GITHUB_ENV"
+          echo "Prepared ${{ env.ASSET_FILES }}"
 
       - name: Create draft release and upload
         uses: softprops/action-gh-release@v2
@@ -210,16 +243,12 @@ jobs:
         with:
           script: |
             const tag = `${{ needs.resolve_tag.outputs.tag }}`;
+            const { owner, repo } = context.repo;
             try {
-              const res = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner, repo: context.repo.repo, tag
-              });
+              const res = await github.rest.repos.getReleaseByTag({ owner, repo, tag });
               const desired = `chd2iso-fuse ${tag}`;
               if (res.data.name !== desired) {
-                await github.rest.repos.updateRelease({
-                  owner: context.repo.owner, repo: context.repo.repo,
-                  release_id: res.data.id, name: desired
-                });
+                await github.rest.repos.updateRelease({ owner, repo, release_id: res.data.id, name: desired });
                 core.info(`Updated release title to '${desired}'`);
               } else {
                 core.info('Release title already correct.');


### PR DESCRIPTION
- Download all artifacts explicitly (pattern: '*') and keep safety guard
- Generate RELEASE_NOTES.md via git-cliff when not provided by build
- Preserve tag guard, identity setup, signing, and draft→publish flow