### PR TITLE
ci(codeql): fix false “no changes” on manual/scheduled runs by overriding paths-filter range

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,10 +33,26 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Provide an explicit compare range for manual/scheduled runs so paths-filter
+      # doesn't fall back to "last commit" (which is often a merge commit with no file list).
+      - name: Compute base/ref for paths-filter (manual/scheduled)
+        id: range
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          head_sha="$(git rev-parse HEAD)"
+          base_sha="$(git rev-parse HEAD^)"
+          echo "base=${base_sha}" >> "$GITHUB_OUTPUT"
+          echo "ref=${head_sha}"  >> "$GITHUB_OUTPUT"
+
       - name: Determine if Rust/package files changed
         id: paths
         uses: dorny/paths-filter@v3
         with:
+          # Override only on manual/scheduled runs; empty values are ignored on PR/push.
+          base: ${{ steps.range.outputs.base }}
+          ref:  ${{ steps.range.outputs.ref }}
           filters: |
             rust:
               - 'src/**'
@@ -76,7 +92,6 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           set -euo pipefail
-          # Generate (in-place) what Cargo believes the lockfile should be
           cargo generate-lockfile
           if ! git diff --quiet -- Cargo.lock; then
             echo "::error file=Cargo.lock::Cargo.lock is out of date. Run 'cargo generate-lockfile' locally and commit the result."


### PR DESCRIPTION
- Add step to compute explicit base/ref (HEAD^..HEAD) for workflow_dispatch/schedule
- Feed base/ref to dorny/paths-filter so merge commits don’t yield empty file lists
- Keep PR fast-path filtering; push/schedule/manual continue to run full analysis