### PR TITLE
Bugfix/ci fix

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -158,23 +158,16 @@ jobs:
             lintian artifacts/*.deb || true
           fi
 
-      - name: Create nightly manifest
-        if: ${{ inputs.nightly && (steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request') }}
+      # --- NEW: deterministic artifact name on tag builds ---
+      - name: Set artifact name
+        id: aname
         run: |
           set -euo pipefail
-          ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          sha="${GITHUB_SHA}"
-          lane="${{ inputs.lane }}"
-          files=$(ls -1 artifacts 2>/dev/null | sed 's/^/  "/; s/$/"/' | paste -sd, - || true)
-          {
-            echo "{"
-            echo "  \"nightly\": true,"
-            echo "  \"timestamp\": \"${ts}\","
-            echo "  \"sha\": \"${sha}\","
-            echo "  \"lane\": \"${lane}\","
-            echo "  \"files\": [ ${files} ]"
-            echo "}"
-          } > artifacts/manifest.json
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "val=release-artifacts" >> "$GITHUB_OUTPUT"
+          else
+            echo "val=chd2iso-fuse-${{ inputs.lane }}-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload nightly artifacts
         if: ${{ inputs.nightly && (steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request') }}
@@ -187,5 +180,6 @@ jobs:
         if: ${{ !inputs.nightly && (steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request') }}
         uses: actions/upload-artifact@v4
         with:
-          name: chd2iso-fuse-${{ inputs.lane }}-${{ github.sha }}
+          name: ${{ steps.aname.outputs.val }}
           path: artifacts/
+          if-no-files-found: error

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -143,6 +143,17 @@ jobs:
             echo "no_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # NEW: keep repo CHANGELOG.md in sync (generated on release/hotfix branch)
+      - name: Prepend this release to CHANGELOG.md (keep file in repo up to date)
+        if: steps.ver.outputs.mode == 'versioned'
+        shell: bash
+        run: |
+          set -euo pipefail
+          v='${{ steps.ver.outputs.value }}'   # e.g. 0.2.16
+          tag="v${v}"
+          git-cliff --tag "${tag}" --prepend CHANGELOG.md
+          git add CHANGELOG.md || true
+
       - name: Detect if Cargo.toml changed in this run
         id: cargo_changed
         if: steps.ver.outputs.mode == 'versioned' && steps.bump.outputs.no_changes == 'false'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,12 @@ jobs:
       - name: Debug tag
         run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
 
-      - name: Download build artifacts (all)
+      # --- NEW: download the deterministic artifact name from _build.yml ---
+      - name: Download build artifacts (release-artifacts)
         uses: actions/download-artifact@v4
         with:
-          pattern: '*'
+          name: release-artifacts
           path: artifacts
-          merge-multiple: true
 
       - name: Guard artifacts exist
         run: |
@@ -133,7 +133,7 @@ jobs:
           shopt -s nullglob
           files=(artifacts/*)
           if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::No artifacts found in ./artifacts"
+            echo "::error::No artifacts found in ./artifacts (expected release-artifacts from _build.yml)"
             exit 1
           fi
           echo "Artifacts downloaded:"
@@ -151,9 +151,6 @@ jobs:
           set -euo pipefail
           if [ -f artifacts/RELEASE_NOTES.md ]; then
             cp artifacts/RELEASE_NOTES.md RELEASE_NOTES.md
-            echo "source=artifact" >> "$GITHUB_OUTPUT"
-          elif [ -f artifacts/CHANGELOG.md ]; then
-            cp artifacts/CHANGELOG.md RELEASE_NOTES.md
             echo "source=artifact" >> "$GITHUB_OUTPUT"
           else
             echo "No notes artifact found; generating with git-cliff…"
@@ -215,7 +212,8 @@ jobs:
             printf '%s\n' "${files[@]}"
             echo 'EOF'
           } >> "$GITHUB_ENV"
-          echo "Prepared ${{ env.ASSET_FILES }}"
+          echo "Prepared files:"
+          printf ' - %s\n' "${files[@]}" || true
 
       - name: Create draft release and upload
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,11 @@ jobs:
     needs: [resolve_tag]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout full history
+      - name: Checkout full history + tags
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Debug refs
         run: |
@@ -140,10 +141,11 @@ jobs:
           find "artifacts" -maxdepth 2 -type f -printf '%P\n' | sort || true
 
       # If build didn't provide notes, generate with git-cliff (tag range)
-      - name: Checkout full history (for changelog generation)
+      - name: Checkout full history + tags (for changelog generation)
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Ensure RELEASE_NOTES.md (prefer provided; otherwise generate via git-cliff)
         id: notes


### PR DESCRIPTION
## CI: stabilize release pipeline, consistent changelogs, deterministic artifacts

- _build.yml: on tag builds upload a single artifact `release-artifacts`.
- release.yml: fetch tags for guard & notes, download `release-artifacts` only,
  prefer notes from artifacts, sign SHA256SUMS if GPG present.
- autobump.yml: prepend current tag section to CHANGELOG.md during release/hotfix
  prep so the repo changelog is merged into main with the branch.

### Outcome:
- GitHub Releases always include .deb, checksums (+ .asc if configured), and
  consistent notes.
- CHANGELOG.md in repo matches the release body; Debian changelog continues to
  use gbp dch with correct upstream version mapping.
