### PR TITLE
Feature/conditional backmerge ci

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -17,8 +17,100 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GATE: affects PRs only; push/schedule/manual always run
+  gate:
+    name: Decide if cargo-deny is needed (PRs)
+    runs-on: ubuntu-latest
+    outputs:
+      needs_ci: ${{ steps.export.outputs.needs_ci }}
+    steps:
+      - name: Mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "is_pr=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export for non-PR
+        if: steps.mode.outputs.is_pr == 'false'
+        id: export_nonpr
+        run: echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+
+      - name: Identify back-merge PR (main → develop)
+        if: steps.mode.outputs.is_pr == 'true'
+        id: bm
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "develop" && \
+                "${{ github.event.pull_request.head.ref }}" == "main" ]]; then
+            echo "is_backmerge=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_backmerge=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout (full, only for back-merge eval)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        uses: actions/checkout@v5
+        with: { fetch-depth: 0 }
+
+      - name: Compare develop…main (ahead/behind)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: compare
+        run: |
+          set -euo pipefail
+          git remote set-url origin "${{ github.server_url }}/${{ github.repository }}"
+          git fetch --no-tags --prune origin \
+            +refs/heads/develop:refs/remotes/origin/develop \
+            +refs/heads/main:refs/remotes/origin/main
+          read A B < <(git rev-list --left-right --count origin/develop...origin/main)
+          echo "ahead_on_develop=${A}" >>"$GITHUB_OUTPUT"
+          echo "behind_on_main=${B}"  >>"$GITHUB_OUTPUT"
+
+      - name: Conflict probe (simulate merge main → develop)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: probe
+        run: |
+          set -euo pipefail
+          git checkout -q -B tmp origin/develop
+          if git merge --no-commit --no-ff origin/main >/dev/null 2>&1; then
+            echo "conflicts=false" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          else
+            echo "conflicts=true" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          fi
+
+      - name: Decide (PR)
+        if: steps.mode.outputs.is_pr == 'true'
+        id: export_pr
+        run: |
+          if [[ "${{ steps.bm.outputs.is_backmerge }}" != "true" ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          A="${{ steps.compare.outputs.ahead_on_develop || '0' }}"
+          C="${{ steps.probe.outputs.conflicts       || 'false' }}"
+          if [[ "$C" == "true" || "$A" -gt 0 ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export final
+        id: export
+        run: |
+          if [[ "${{ steps.mode.outputs.is_pr }}" == "true" ]]; then
+            echo "needs_ci=${{ steps.export_pr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=${{ steps.export_nonpr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          fi
+
   deny:
     name: cargo-deny
+    needs: gate
+    # Only gate PRs; push/schedule/manual runs are unaffected
+    if: needs.gate.outputs.needs_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,108 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GATE: decide whether heavy CI is needed for PRs (incl. conflict probe)
+  gate:
+    name: Decide if heavy CI is needed (PRs)
+    runs-on: ubuntu-latest
+    outputs:
+      needs_ci: ${{ steps.export.outputs.needs_ci }}
+    steps:
+      - name: Mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "is_pr=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      # Non-PR paths (i.e., push): always run
+      - name: Export for push
+        if: steps.mode.outputs.is_pr == 'false'
+        id: export_push
+        run: echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+
+      # Identify back-merge PR (main → develop)
+      - name: Identify back-merge PR
+        if: steps.mode.outputs.is_pr == 'true'
+        id: bm
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "develop" && \
+                "${{ github.event.pull_request.head.ref }}" == "main" ]]; then
+            echo "is_backmerge=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_backmerge=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      # For back-merge evaluation we need full refs
+      - name: Checkout (full)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Compare develop…main (ahead/behind)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: compare
+        run: |
+          set -euo pipefail
+          git remote set-url origin "${{ github.server_url }}/${{ github.repository }}"
+          git fetch --no-tags --prune origin \
+            +refs/heads/develop:refs/remotes/origin/develop \
+            +refs/heads/main:refs/remotes/origin/main
+          read A B < <(git rev-list --left-right --count origin/develop...origin/main)
+          echo "ahead_on_develop=${A}" >>"$GITHUB_OUTPUT"
+          echo "behind_on_main=${B}"  >>"$GITHUB_OUTPUT"
+
+      - name: Conflict probe (simulate merge main → develop)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: probe
+        run: |
+          set -euo pipefail
+          git checkout -q -B tmp origin/develop
+          if git merge --no-commit --no-ff origin/main >/dev/null 2>&1; then
+            echo "conflicts=false" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          else
+            echo "conflicts=true" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          fi
+
+      - name: Decide (PR)
+        if: steps.mode.outputs.is_pr == 'true'
+        id: export_pr
+        run: |
+          # Non-backmerge PRs always run heavy CI
+          if [[ "${{ steps.bm.outputs.is_backmerge }}" != "true" ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          A="${{ steps.compare.outputs.ahead_on_develop || '0' }}"
+          C="${{ steps.probe.outputs.conflicts || 'false' }}"
+          if [[ "$C" == "true" || "$A" -gt 0 ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export final
+        id: export
+        run: |
+          if [[ "${{ steps.mode.outputs.is_pr }}" == "true" ]]; then
+            echo "needs_ci=${{ steps.export_pr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=${{ steps.export_push.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          fi
+
   build_test:
     name: Build & Test (Linux)
-    # Don’t rerun for the bot’s prep commits
-    if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[ci skip]')"
+    needs: gate
+    # Keep your existing "skip ci" guard, and only gate PRs; pushes unaffected
+    if: >
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, '[ci skip]') &&
+      (github.event_name != 'pull_request' || needs.gate.outputs.needs_ci == 'true')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,13 +116,42 @@ jobs:
             echo "needs_ci=${{ steps.export_push.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
           fi
 
+  # Always-on quick sanity for PRs (even if heavy CI is skipped)
+  quick_sanity:
+    name: Quick sanity (fmt + check)
+    needs: gate
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (shallow)
+        uses: actions/checkout@v4
+        with: { fetch-depth: 1 }
+
+      - name: Install system deps (minimal)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends pkg-config libfuse3-dev
+
+      - name: Setup Rust (stable, rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: fmt
+        run: cargo fmt --all -- --check
+
+      - name: Smoke compile (fast)
+        env: { CARGO_TERM_COLOR: always }
+        run: cargo check --workspace --locked --all-features
+
   build_test:
     name: Build & Test (Linux)
     needs: gate
     # Keep your existing "skip ci" guard, and only gate PRs; pushes unaffected
     if: >
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
+      !contains(github.event_head_commit.message, '[skip ci]') &&
+      !contains(github.event_head_commit.message, '[ci skip]') &&
       (github.event_name != 'pull_request' || needs.gate.outputs.needs_ci == 'true')
     runs-on: ubuntu-latest
 
@@ -178,8 +207,8 @@ jobs:
     needs: build_test
     if: >
       github.event_name == 'push' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
+      !contains(github.event_head_commit.message, '[skip ci]') &&
+      !contains(github.event_head_commit.message, '[ci skip]') &&
       (github.ref_name == 'main' || startsWith(github.ref_name, 'release/'))
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,8 +18,91 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GATE: only affects PRs; push/schedule/manual still run
+  gate:
+    name: Decide if CodeQL is needed (PRs)
+    runs-on: ubuntu-latest
+    outputs:
+      needs_ci: ${{ steps.export.outputs.needs_ci }}
+    steps:
+      - name: Mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "is_pr=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export for non-PR
+        if: steps.mode.outputs.is_pr == 'false'
+        id: export_nonpr
+        run: echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+
+      - name: Identify back-merge PR
+        if: steps.mode.outputs.is_pr == 'true'
+        id: bm
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "develop" && \
+                "${{ github.event.pull_request.head.ref }}" == "main" ]]; then
+            echo "is_backmerge=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_backmerge=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        with: { fetch-depth: 0 }
+
+      - name: Compare & probe (only for back-merge PRs)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          git remote set-url origin "${{ github.server_url }}/${{ github.repository }}"
+          git fetch --no-tags --prune origin \
+            +refs/heads/develop:refs/remotes/origin/develop \
+            +refs/heads/main:refs/remotes/origin/main
+          read A B < <(git rev-list --left-right --count origin/develop...origin/main)
+          echo "ahead_on_develop=${A}" >>"$GITHUB_OUTPUT"
+          git checkout -q -B tmp origin/develop
+          if git merge --no-commit --no-ff origin/main >/dev/null 2>&1; then
+            echo "conflicts=false" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          else
+            echo "conflicts=true" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          fi
+
+      - name: Decide (PR)
+        if: steps.mode.outputs.is_pr == 'true'
+        id: export_pr
+        run: |
+          if [[ "${{ steps.bm.outputs.is_backmerge }}" != "true" ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          A="${{ steps.diff.outputs.ahead_on_develop || '0' }}"
+          C="${{ steps.diff.outputs.conflicts || 'false' }}"
+          if [[ "$C" == "true" || "$A" -gt 0 ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export final
+        id: export
+        run: |
+          if [[ "${{ steps.mode.outputs.is_pr }}" == "true" ]]; then
+            echo "needs_ci=${{ steps.export_pr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=${{ steps.export_nonpr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          fi
+
   analyze:
     name: "Analyze (CodeQL: ${{ matrix.variant }})"
+    needs: gate
+    if: needs.gate.outputs.needs_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -17,8 +17,91 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GATE: only affects PRs; push/schedule/manual still run
+  gate:
+    name: Decide if audit is needed (PRs)
+    runs-on: ubuntu-latest
+    outputs:
+      needs_ci: ${{ steps.export.outputs.needs_ci }}
+    steps:
+      - name: Mode
+        id: mode
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "is_pr=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export for non-PR
+        if: steps.mode.outputs.is_pr == 'false'
+        id: export_nonpr
+        run: echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+
+      - name: Identify back-merge PR
+        if: steps.mode.outputs.is_pr == 'true'
+        id: bm
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == "develop" && \
+                "${{ github.event.pull_request.head.ref }}" == "main" ]]; then
+            echo "is_backmerge=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "is_backmerge=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        with: { fetch-depth: 0 }
+
+      - name: Compare & probe (only for back-merge PRs)
+        if: steps.mode.outputs.is_pr == 'true' && steps.bm.outputs.is_backmerge == 'true'
+        id: diff
+        run: |
+          set -euo pipefail
+          git remote set-url origin "${{ github.server_url }}/${{ github.repository }}"
+          git fetch --no-tags --prune origin \
+            +refs/heads/develop:refs/remotes/origin/develop \
+            +refs/heads/main:refs/remotes/origin/main
+          read A B < <(git rev-list --left-right --count origin/develop...origin/main)
+          echo "ahead_on_develop=${A}" >>"$GITHUB_OUTPUT"
+          git checkout -q -B tmp origin/develop
+          if git merge --no-commit --no-ff origin/main >/dev/null 2>&1; then
+            echo "conflicts=false" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          else
+            echo "conflicts=true" >>"$GITHUB_OUTPUT"
+            git merge --abort || true
+          fi
+
+      - name: Decide (PR)
+        if: steps.mode.outputs.is_pr == 'true'
+        id: export_pr
+        run: |
+          if [[ "${{ steps.bm.outputs.is_backmerge }}" != "true" ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+          A="${{ steps.diff.outputs.ahead_on_develop || '0' }}"
+          C="${{ steps.diff.outputs.conflicts || 'false' }}"
+          if [[ "$C" == "true" || "$A" -gt 0 ]]; then
+            echo "needs_ci=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=false" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Export final
+        id: export
+        run: |
+          if [[ "${{ steps.mode.outputs.is_pr }}" == "true" ]]; then
+            echo "needs_ci=${{ steps.export_pr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          else
+            echo "needs_ci=${{ steps.export_nonpr.outputs.needs_ci }}" >>"$GITHUB_OUTPUT"
+          fi
+
   cargo-audit:
     name: cargo-audit
+    needs: gate
+    if: needs.gate.outputs.needs_ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 


### PR DESCRIPTION
### Summary
This PR refines our CI workflows to avoid wasting minutes on safe back-merges from `main` into `develop`, while still ensuring a baseline of checks always run.

### Changes
- Added a **gate job** with ahead/behind comparison and conflict probe:
  - Skips heavy jobs for back-merge PRs when `develop` has not progressed and merge is conflict-free.
  - Runs heavy jobs normally if `develop` is ahead or conflicts would occur.
- Applied the gate consistently across:
  - `ci.yml` (build & test)
  - `codeql.yml`
  - `security-audit.yml` (cargo-audit)
  - `cargo-deny.yml`
- Introduced a **`quick_sanity` job** in `ci.yml`:
  - Always runs for PRs, even when heavy CI is skipped.
  - Runs `cargo fmt --check` and a fast `cargo check` as a lightweight safety net.
- Push, schedule, and workflow_dispatch jobs remain unaffected.

### Why
- Back-merge PRs contain only code that has already been tested and released via `main`.
- This saves CI time and minutes while still ensuring `develop` isn’t broken.
- The quick sanity job ensures all PRs at least prove formatting and compilation.

### Next steps
- Branch protection can later be configured to require `quick_sanity` (always runs) instead of heavy jobs, to avoid merge blocks on skipped jobs.
