### PR TITLE
Bugfix/ci release

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -146,7 +146,7 @@ jobs:
             (cd artifacts && sha256sum * > SHA256SUMS)
           fi
           
-      - name: Guard: at least one .deb was built
+      - name: Guard at least one .deb was built
         if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
         shell: bash
         run: |

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -145,6 +145,22 @@ jobs:
           if compgen -G "artifacts/*" > /dev/null; then
             (cd artifacts && sha256sum * > SHA256SUMS)
           fi
+          
+      - name: Guard: at least one .deb was built
+        if: ${{ steps.paths.outputs.rust == 'true' || github.event_name != 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          debs=(artifacts/*.deb)
+          if [ ${#debs[@]} -eq 0 ]; then
+            echo "::error::No .deb files found in artifacts/. Build or packaging likely failed."
+            echo "Listing artifacts dir for debugging:"
+            ls -la artifacts || true
+            exit 1
+          fi
+          echo "Found ${#debs[@]} .deb file(s):"
+          printf ' - %s\n' "${debs[@]}"
 
       # Generate release notes when either (a) this is a real tag event, or (b) release_mode is forced by caller
       - name: Generate release notes (git-cliff) for release
@@ -182,7 +198,6 @@ jobs:
           else
             echo "val=chd2iso-fuse-${{ inputs.lane }}-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           fi
-          echo "Artifact name: $(cat "$GITHUB_OUTPUT" | sed -n 's/^val=//p')"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -190,3 +205,11 @@ jobs:
           name: ${{ steps.aname.outputs.val }}
           path: artifacts/
           if-no-files-found: error
+
+      - name: Debug: list artifact contents
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Local artifacts/ contents prior to upload:"
+          find artifacts -maxdepth 1 -type f -printf '%P\n' | sort || true

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -206,7 +206,7 @@ jobs:
           path: artifacts/
           if-no-files-found: error
 
-      - name: Debug: list artifact contents
+      - name: Debug list artifact contents
         if: always()
         shell: bash
         run: |

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -36,7 +36,6 @@ jobs:
                 );
                 const pr = prs.find(p => p.merged_at && p.base?.ref === 'main');
                 if (pr) return pr;
-                // brief backoff to allow GitHub to index associations
                 await new Promise(r => setTimeout(r, 2000));
               }
               return null;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,17 +128,35 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Guard artifacts exist
+      - name: Debug: list downloaded artifact contents
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Downloaded files:"
+          find artifacts -maxdepth 1 -type f -printf '%P\n' | sort || true
+
+      - name: Guard: expected release payload present (.deb and notes)
+        shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
           files=(artifacts/*)
           if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::No artifacts found in ./artifacts"
+            echo "::error::No files in artifacts/ (expected release-artifacts)."
             exit 1
           fi
+
+          debs=(artifacts/*.deb)
+          if [ ${#debs[@]} -eq 0 ]; then
+            echo "::error::No .deb files found in artifacts/."
+            echo "Contents:"
+            find artifacts -maxdepth 2 -type f -printf '%P\n' | sort || true
+            exit 1
+          fi
+
           echo "Artifacts downloaded:"
-          find "artifacts" -maxdepth 2 -type f -printf '%P\n' | sort || true
+          find artifacts -maxdepth 2 -type f -printf '%P\n' | sort || true
 
       # If build didn't provide notes, generate with git-cliff (using -u)
       - name: Checkout full history (for changelog generation)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
           body_path: "RELEASE_NOTES.md"
           generate_release_notes: false
           draft: true
-          fail_on_unmatched_files: false
+          fail_on_unmatched_files: true
           files: ${{ env.ASSET_FILES }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Debug: list downloaded artifact contents
+      - name: Debug list downloaded artifact contents
         if: always()
         shell: bash
         run: |
@@ -136,7 +136,7 @@ jobs:
           echo "Downloaded files:"
           find artifacts -maxdepth 1 -type f -printf '%P\n' | sort || true
 
-      - name: Guard: expected release payload present (.deb and notes)
+      - name: Guard expected release payload present (.deb and notes)
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,11 @@ jobs:
     needs: [resolve_tag]
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout full history
+      - name: Checkout full history + tags
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Debug refs
         run: |
@@ -121,12 +122,11 @@ jobs:
       - name: Debug tag
         run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
 
-      - name: Download build artifacts (all)
+      - name: Download build artifacts (release-artifacts)
         uses: actions/download-artifact@v4
         with:
-          pattern: '*'
+          name: release-artifacts
           path: artifacts
-          merge-multiple: true
 
       - name: Debug list downloaded artifact contents
         if: always()
@@ -159,10 +159,11 @@ jobs:
           find artifacts -maxdepth 2 -type f -printf '%P\n' | sort || true
 
       # If build didn't provide notes, generate with git-cliff (using -u)
-      - name: Checkout full history (for changelog generation)
+      - name: Checkout full history + tags (for changelog generation)
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Ensure RELEASE_NOTES.md (prefer provided; otherwise generate via git-cliff)
         id: notes

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,6 +1,6 @@
 [git]
 # Match tags like v0.1.6
-tag_pattern = "^v\\d+\\.\\d+\\.\\d+$"
+tag_pattern = "^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$"
 # We don't force Conventional Commits; messages still work fine.
 conventional_commits = false
 


### PR DESCRIPTION
# CI/Release hardening: deterministic artifacts, fail-fast packaging, robust back-merge

## Summary
This branch stabilizes the release pipeline and CI around three themes:

1. **Deterministic release artifacts**
   - `_build.yml`: new `release_mode` input forces tag-like behavior (uploads as `release-artifacts`).
   - `release.yml`: downloads **`release-artifacts`** explicitly; `fail_on_unmatched_files: true`.
   - Guard steps ensure a **.deb** exists before publishing; SHA256SUMS (and `.asc` if GPG present) are included.

2. **Reliable changelogs & tag history**
   - `autobump.yml`: prepends current tag to `CHANGELOG.md`; generates `RELEASE_NOTES.md`.
   - `release.yml`: adds `fetch-tags: true` to both checkout points so git-cliff gets the full tag graph.

3. **Back-merge automation & CI hygiene**
   - `merge.yml`: hardened PR detection with retry + fallback; opens/merges back-merge PR `main → develop`.
   - CI jobs (ci/codeql/audits) skip heavy work on back-merge PRs (manual or auto).
   - Cache warnings fixed by pre-creating cache dirs; `runs-on` alignment fixed in `ci.yml`.

## Files touched (high level)
- **`_build.yml`**
  - Add `release_mode`; enforce `.deb`-present guard; deterministic artifact name; debug listing.
- **`release.yml`**
  - Fetch tags on checkouts; download **`release-artifacts`**; stricter artifact guard; debug listing; strict file matching.
- **`merge.yml`**
  - Hardened `detect` job (retry + fallback); back-merge flow unchanged otherwise.
- **`autobump.yml`**
  - Prepend current tag to `CHANGELOG.md` (already merged earlier in this branch).

## Why this helps
- Prevents “notes-only” releases by **failing fast** if packaging produced no `.deb`.
- Ensures GitHub releases always include `.deb`, `SHA256SUMS`, and (optionally) `SHA256SUMS.asc`.
- Makes tag-derived changelogs consistent across Debian, GitHub Releases, and `CHANGELOG.md`.
- Back-merge PRs are created even if GitHub lags on PR→commit association.

## Checks performed
- Verified artifact upload as **`release-artifacts`** in `_build.yml`.
- Verified `release.yml` now **requires a `.deb`** before publishing.
- Confirmed `fetch-tags: true` on both checkouts used for guards/changelog.
- Confirmed back-merge detection uses retry + fallback and has permissions.

## Rollout / Test plan
1. Merge to `develop`.
2. Open a test PR `main → develop` titled “Back-merge … (test)” → heavy CI should be **skipped**; quick sanity still runs.
3. Create a throwaway tag `v0.0.0` and dispatch `release.yml`:
   - Expect failure if no `.deb` is produced (by design).
   - When packaging is present, expect `.deb`, `SHA256SUMS` (and `.asc` if GPG) on the Release.

## Notes / prerequisites
- Repo Settings → Actions → **Workflow permissions = Read and write**.
- Secrets: `RELEASE_PAT` (required), `GPG_PRIVATE_KEY` & `GPG_PASSPHRASE` (optional for signing).
- Optional: in `cliff.toml`, allow RC tags via  
  `tag_pattern = "^v\\d+\\.\\d+\\.\\d+(-rc\\d+)?$"` if you plan RC releases.

---
