### PR TITLE
fix(ci): fail-fast on missing release artifacts & broaden back-merge detection

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -234,18 +234,22 @@ jobs:
           echo "ahead_by:      ${{ steps.compare.outputs.ahead_by }}"
           echo "behind_by:     ${{ steps.compare.outputs.behind_by }}"
 
+      # NEW: broaden condition + echo decision
       - name: Decide if back-merge is needed
         id: gate
         env:
           STATUS: ${{ steps.compare.outputs.status }}
+          AHEAD:  ${{ steps.compare.outputs.ahead_by }}
+          BEHIND: ${{ steps.compare.outputs.behind_by }}
         run: |
           set -euo pipefail
-          if [[ "$STATUS" == "behind" || "$STATUS" == "diverged" ]]; then
+          echo "Compare summary: status=${STATUS} ahead_by=${AHEAD} behind_by=${BEHIND}"
+          # Open a back-merge whenever branches are NOT identical
+          if [[ "${STATUS}" != "identical" ]]; then
             echo "should_backmerge=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_backmerge=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "Status: $STATUS"
 
       - name: Check for existing open PR main -> develop
         id: existing
@@ -266,9 +270,16 @@ jobs:
               core.info('No existing PR main -> develop');
             }
 
+      - name: Debug decision
+        if: always()
+        run: |
+          echo "gate.should_backmerge=${{ steps.gate.outputs.should_backmerge }}"
+          echo "existing.exists=${{ steps.existing.outputs.exists }}"
+          echo "existing.number=${{ steps.existing.outputs.number }}"
+
       - name: No back-merge needed
         if: ${{ steps.gate.outputs.should_backmerge != 'true' }}
-        run: echo "Develop is not behind; skipping PR."
+        run: echo "Develop is not behind/diverged; skipping PR."
 
       - name: Open PR main -> develop
         id: create_pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
     with:
       lane: main
       nightly: false
-      release_mode: true   # <— NEW: force release behavior even on workflow_dispatch
+      release_mode: true   # force release behavior even on workflow_dispatch
     secrets: inherit
 
   verify_versions:
@@ -121,6 +121,24 @@ jobs:
 
       - name: Debug tag
         run: echo "tag=${{ needs.resolve_tag.outputs.tag }}"
+
+      # NEW: assert the build uploaded the expected artifact
+      - name: Assert build artifact 'release-artifacts' exists in this run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const run_id = context.runId;
+            const arts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner, repo, run_id, per_page: 100
+            });
+            const names = arts.map(a => a.name);
+            core.info('Artifacts on this run: ' + JSON.stringify(names));
+            const found = arts.find(a => a.name === 'release-artifacts');
+            if (!found) {
+              core.setFailed("Missing expected artifact 'release-artifacts'. " +
+                "Check the _build.yml logs (did the .deb guard fire? did upload-artifact run?)");
+            }
 
       - name: Download build artifacts (release-artifacts)
         uses: actions/download-artifact@v4
@@ -186,7 +204,7 @@ jobs:
         with:
           tool: git-cliff
 
-      # NEW: also prepend to CHANGELOG.md and generate RELEASE_NOTES.md using -u
+      # also prepend to CHANGELOG.md and generate RELEASE_NOTES.md using -u
       - name: Generate changelog and notes with git-cliff (-u)
         if: steps.notes.outputs.source == 'cliff'
         run: |


### PR DESCRIPTION
- release.yml: • Added explicit check for `release-artifacts` in workflow run before download. • Switched download to use explicit name (`release-artifacts`). • Fetch tags in both checkout steps (tag guard + changelog generation) to ensure git-cliff and ancestry checks see the full tag graph. • Retains guard to fail if no .deb files present.

- merge.yml: • Broadened back-merge condition: trigger whenever `main` and `develop` are not identical (not just “behind” or “diverged”). • Added extra debug logging (compare summary, gate decision, existing PR state).

#### Outcome:
- Prevents publishing notes-only releases when artifacts are missing or misnamed.
- Guarantees releases include .deb and checksums, or fail clearly.
- Back-merge PRs now open reliably with clear debug info when branches differ.