### PR TITLE
fix(release): prevent checkout from wiping build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,14 @@ jobs:
           if [ "${HAS_AUTHOR_NAME}" != "true" ]; then echo "::warning::Variable GIT_AUTHOR_NAME is not set (will use default)."; fi
           if [ "${HAS_AUTHOR_EMAIL}" != "true" ]; then echo "::warning::Variable GIT_AUTHOR_EMAIL is not set (will use default)."; fi
 
+      # ⬅️ Move checkout BEFORE any artifact downloads, and disable clean
+      - name: Checkout full history + tags (for changelog generation)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          clean: false   # <— do NOT wipe downloaded artifacts
+
       - name: Configure git identity (from Actions Variables)
         run: |
           set -euo pipefail
@@ -176,13 +184,6 @@ jobs:
           echo "Artifacts downloaded:"
           find artifacts -maxdepth 2 -type f -printf '%P\n' | sort || true
 
-      # If build didn't provide notes, generate with git-cliff (using -u)
-      - name: Checkout full history + tags (for changelog generation)
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Ensure RELEASE_NOTES.md (prefer provided; otherwise generate via git-cliff)
         id: notes
         run: |
@@ -210,16 +211,9 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${{ needs.resolve_tag.outputs.tag }}"
-
-          # Ensure CHANGELOG.md exists so --prepend works idempotently
           [[ -f CHANGELOG.md ]] || printf "# Changelog\n\n" > CHANGELOG.md
-
-          # Collect unreleased commits since previous tag, label as TAG, prepend to changelog
           git-cliff --tag "${TAG}" -u --prepend CHANGELOG.md
-
-          # Emit notes for the release body
           git-cliff --tag "${TAG}" -u --output RELEASE_NOTES.md
-
           sed -n '1,120p' RELEASE_NOTES.md || true
 
       # 🔐 SIGN BEFORE ASSEMBLING THE UPLOAD LIST
@@ -238,14 +232,12 @@ jobs:
               -o artifacts/SHA256SUMS.asc artifacts/SHA256SUMS
           gpg --verify artifacts/SHA256SUMS.asc artifacts/SHA256SUMS
 
-      # Assemble assets as a STEP OUTPUT (explicit files only)
       - name: Assemble release asset list (explicit)
         id: assets
         shell: bash
         run: |
           set -euo pipefail
           shopt -s nullglob
-
           # Pick only what we want to publish
           wanted=( artifacts/*.deb artifacts/SHA256SUMS artifacts/SHA256SUMS.asc artifacts/CHANGELOG.md artifacts/RELEASE_NOTES.md )
           files=()
@@ -256,17 +248,11 @@ jobs:
               files+=("$(basename "$x")")
             done
           done
-
           if [ ${#files[@]} -eq 0 ]; then
-            echo "::error::No release asset files were gathered."
-            echo "Artifacts dir contents (depth 2):"
-            find artifacts -maxdepth 2 -type f -printf '%P\n' | sort || true
-            exit 1
+            echo "::error::No files selected for upload"; exit 1
           fi
-
-          printf 'Will upload %d file(s):\n' "${#files[@]}"
+          echo "Will upload ${#files[@]} file(s):"
           printf ' - %s\n' "${files[@]}"
-
           {
             echo "files<<EOF"
             printf '%s\n' "${files[@]}"
@@ -278,24 +264,20 @@ jobs:
           echo "Files:"
           echo "${{ steps.assets.outputs.files }}" | sed 's/^/  - /'
 
-      # ===== switched to GitHub CLI for robust uploads =====
       - name: Create/ensure draft release (no assets yet)
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.resolve_tag.outputs.tag }}
-          name: "chd2iso-fuse ${{ needs.resolve_tag.outputs.tag }}"
-          body_path: "RELEASE_NOTES.md"
-          generate_release_notes: false
-          draft: true
-          fail_on_unmatched_files: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.resolve_tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release create "${TAG}" -t "chd2iso-fuse ${TAG}" -F RELEASE_NOTES.md --draft
+          fi
 
       - name: Upload assets via gh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.resolve_tag.outputs.tag }}
-        shell: bash
         run: |
           set -euo pipefail
           mapfile -t files < <(printf '%s\n' "${{ steps.assets.outputs.files }}")
@@ -310,9 +292,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.resolve_tag.outputs.tag }}
-        run: gh release edit "${TAG}" --draft=false
+        run: |
+          set -euo pipefail
+          gh release edit "${TAG}" --draft=false
 
-      # Optional: verify assets attached to the release
       - name: Verify release assets (debug)
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
- Moved checkout step before artifact download in `publish_release`
- Added `clean: false` to checkout so downloaded files are preserved
- Removed duplicate checkout later in the job
- Explicitly assemble and upload only expected files (.deb, checksums, notes)
- Added debug verification of release assets after upload

Outcome: ensures .deb packages and SHA256SUMS survive to be attached to GitHub Releases instead of being removed by checkout.