### PR TITLE
ci: add lint & test workflow for shell scripts

### DIFF
--- a/.github/workflows/scripts-lint-test.yml
+++ b/.github/workflows/scripts-lint-test.yml
@@ -1,5 +1,5 @@
 # .github/workflows/scripts-lint-test.yml
-name: Scripts 🔧 Lint & Test
+name: Scripts 🔧🐚 Lint & Test ✅
 
 on:
   push:
@@ -22,43 +22,44 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint (shellcheck + shfmt)
+    name: 🔍 Lint (shellcheck + shfmt) 🎨
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install shellcheck & shfmt
+      - name: 📦 Install shellcheck & shfmt
         run: |
           sudo apt-get update
           sudo apt-get install -y shellcheck
           sudo bash -lc 'curl -sSLo /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/latest/download/shfmt_linux_amd64; chmod +x /usr/local/bin/shfmt'
 
-      - name: shellcheck
+      - name: 🕵️ Run shellcheck
         run: |
           set -euo pipefail
           mapfile -t FILES < <(git ls-files '*.sh' 'scripts/*' 2>/dev/null || true)
           [ ${#FILES[@]} -gt 0 ] || { echo "No shell files."; exit 0; }
           shellcheck "${FILES[@]}"
 
-      - name: Check formatting (shfmt)
+      - name: 🎨 Check formatting (shfmt)
         run: |
           set -euo pipefail
           mapfile -t FILES < <(git ls-files '*.sh' 'scripts/*' 2>/dev/null || true)
           [ ${#FILES[@]} -gt 0 ] || exit 0
-          # Check mode (no writes): fail if diff is needed
           shfmt -i 2 -ci -sr -d "${FILES[@]}"
 
   test:
-    name: Tests (bats)
+    name: 🧪 Run bats tests 🐒
     runs-on: ubuntu-latest
     needs: lint
     steps:
       - uses: actions/checkout@v4
-      - name: Install bats
+
+      - name: 📦 Install bats
         run: |
           sudo apt-get update
           sudo apt-get install -y bats
-      - name: Run bats tests
+
+      - name: ▶️ Run bats
         run: |
           if compgen -G "tests/**/*.bats" > /dev/null; then
             bats -r tests

--- a/.github/workflows/scripts-lint-test.yml
+++ b/.github/workflows/scripts-lint-test.yml
@@ -1,0 +1,67 @@
+# .github/workflows/scripts-lint-test.yml
+name: Scripts 🔧 Lint & Test
+
+on:
+  push:
+    branches: [ develop, main ]
+    paths:
+      - "scripts/**"
+      - "**/*.sh"
+  pull_request:
+    branches: [ develop, main ]
+    paths:
+      - "scripts/**"
+      - "**/*.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scripts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint (shellcheck + shfmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck & shfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          sudo bash -lc 'curl -sSLo /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/latest/download/shfmt_linux_amd64; chmod +x /usr/local/bin/shfmt'
+
+      - name: shellcheck
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(git ls-files '*.sh' 'scripts/*' 2>/dev/null || true)
+          [ ${#FILES[@]} -gt 0 ] || { echo "No shell files."; exit 0; }
+          shellcheck "${FILES[@]}"
+
+      - name: Check formatting (shfmt)
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(git ls-files '*.sh' 'scripts/*' 2>/dev/null || true)
+          [ ${#FILES[@]} -gt 0 ] || exit 0
+          # Check mode (no writes): fail if diff is needed
+          shfmt -i 2 -ci -sr -d "${FILES[@]}"
+
+  test:
+    name: Tests (bats)
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats
+      - name: Run bats tests
+        run: |
+          if compgen -G "tests/**/*.bats" > /dev/null; then
+            bats -r tests
+          else
+            echo "No bats tests found; skipping."
+          fi


### PR DESCRIPTION
ci: 🤖✨ add lint & test workflow for shell scripts 🐚✅

Introduce a new GitHub Actions workflow (scripts-lint-test.yml) to check
helper shell scripts. The workflow runs on pushes and PRs that touch
*.sh files or scripts/**. It performs:

- 🕵️ shellcheck static analysis
- 🎨 shfmt formatting check (non-destructive, fail on diff)
- 🧪 optional bats tests (if present)

This ensures script quality without risk of CI feedback loops 🔁🚫.