### PR TITLE
ci(release): wire build to resolve_tag + log TAG in notes generation

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -164,11 +164,9 @@ jobs:
           echo "Found ${#debs[@]} .deb file(s):"
           printf ' - %s\n' "${debs[@]}"
 
-      # Install git-cliff once via the official action (no curl)
       - name: 🧰 Set up git-cliff
         if: ${{ inputs.release_mode || startsWith(github.ref, 'refs/tags/') }}
-        uses: taiki-e/install-action@git-cliff  # recommended by git-cliff docs
-        # refs: https://git-cliff.org/docs/github-actions/taiki-e-install-action/
+        uses: taiki-e/install-action@git-cliff
 
       # Canonical one-time generation of RELEASE_NOTES.md and CHANGELOG.md
       - name: 📝 Generate release notes & CHANGELOG (git-cliff) — canonical
@@ -185,6 +183,7 @@ jobs:
             echo "::error::No TAG provided to _build.yml for release_mode build."
             exit 1
           fi
+          echo "Using TAG: $TAG"
 
           NOTES="RELEASE_NOTES.md"
           : > "$NOTES"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
   build:
     name: 🛠️ Build for tag
-    needs: [guard_tag_on_main]
+    needs: [guard_tag_on_main, resolve_tag]   # ← include resolve_tag so outputs are available
     uses: ./.github/workflows/_build.yml
     with:
       lane: main
@@ -261,10 +261,9 @@ jobs:
       - name: 🚀 Publish the release (gh)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ needs.resolve_tag.outputs.tag }}
         run: |
           set -euo pipefail
-          gh release edit "${TAG}" --draft=false
+          gh release edit "${{ needs.resolve_tag.outputs.tag }}" --draft=false
 
       - name: 🐛 Verify release assets (debug)
         uses: actions/github-script@v8
@@ -289,7 +288,6 @@ jobs:
               core.info(`Updated release title to '${desired}'`);
             } else {
               core.info('Release title already correct.');
-            }
 
   release_lane:
     name: 🛣️ Release lane and optional APT


### PR DESCRIPTION
- Make `build` depend on both `guard_tag_on_main` and `resolve_tag` so `${{ needs.resolve_tag.outputs.tag }}` is available to the reusable workflow.
- _build.yml: echo the resolved tag (“Using TAG: …”) in the canonical release-notes/CHANGELOG generation step for clearer diagnostics.

Fixes the “No TAG provided to _build.yml for release_mode build.” failure and ensures RELEASE_NOTES/CHANGELOG are generated against the correct tag.