### PR TITLE
ci(cleanup): add artifact retention + post-publish deletion + weekly prune

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -245,6 +245,7 @@ jobs:
           name: ${{ steps.aname.outputs.val }}
           path: artifacts/
           if-no-files-found: error
+          retention-days: 3 # <- keep short; we also delete after publish
 
       - name: 🧾 Debug list artifact contents
         if: always()

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,79 @@
+name: 🧹 Cleanup CI storage
+
+on:
+  schedule:
+    - cron: '20 3 * * 0'    # Sundays 03:20 UTC
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cleanup
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🧽 Delete old artifacts
+        uses: actions/github-script@v8
+        env:
+          ARTIFACT_DAYS: '14'            # delete artifacts older than X days
+          KEEP_NAMES: '[]'               # e.g. '["release-artifacts"]'
+        with:
+          script: |
+            const cutoffDays = parseInt(process.env.ARTIFACT_DAYS || '14', 10);
+            const cutoff = new Date(Date.now() - cutoffDays * 24*60*60*1000);
+            const keep = new Set(JSON.parse(process.env.KEEP_NAMES || '[]'));
+
+            const { owner, repo } = context.repo;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              { owner, repo, per_page: 100 }
+            );
+
+            let deleted = 0, kept = 0;
+            for (const a of artifacts) {
+              const created = new Date(a.created_at);
+              const keepByName = keep.has(a.name);
+              if (keepByName || created >= cutoff) { kept++; continue; }
+              try {
+                await github.rest.actions.deleteArtifact({ owner, repo, artifact_id: a.id });
+                deleted++;
+                core.info(`Deleted artifact ${a.name} (#${a.id}) created ${a.created_at}`);
+              } catch (err) {
+                core.warning(`Could not delete artifact ${a.name} (#${a.id}): ${err.message}`);
+              }
+            }
+            core.info(`Artifacts: kept=${kept} deleted=${deleted}`);
+
+      - name: 🗑️ Delete old completed workflow runs
+        uses: actions/github-script@v8
+        env:
+          RUN_DAYS: '45'                  # delete runs older than X days
+        with:
+          script: |
+            const cutoffDays = parseInt(process.env.RUN_DAYS || '45', 10);
+            const cutoff = new Date(Date.now() - cutoffDays * 24*60*60*1000);
+            const { owner, repo } = context.repo;
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              { owner, repo, per_page: 100, status: 'completed' }
+            );
+
+            let deleted = 0, kept = 0;
+            for (const r of runs) {
+              const created = new Date(r.created_at);
+              if (created >= cutoff) { kept++; continue; }
+              try {
+                await github.rest.actions.deleteWorkflowRun({ owner, repo, run_id: r.id });
+                deleted++;
+                core.info(`Deleted run #${r.id} (${r.name} @ ${r.head_branch}) created ${r.created_at}`);
+              } catch (err) {
+                core.warning(`Could not delete run #${r.id}: ${err.message}`);
+              }
+            }
+            core.info(`Runs: kept=${kept} deleted=${deleted}`);

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,12 @@ jobs:
         run: |
           set -euo pipefail
           gh release edit "${{ needs.resolve_tag.outputs.tag }}" --draft=false
+      
+      - name: 🧹 Delete build artifact bundle (release-artifacts)
+        uses: geekyeggo/delete-artifact@v5
+        with:
+          name: release-artifacts
+        continue-on-error: true
 
       - name: 🐛 Verify release assets (debug)
         uses: actions/github-script@v8


### PR DESCRIPTION
# ci(cleanup): artifact retention, post-publish deletion, and weekly pruning

## Summary
Keep CI storage tidy without affecting releases. This PR:
1) Sets a short retention on the build artifact used by the release pipeline.
2) Deletes that artifact right after the release is published.
3) Adds a scheduled cleanup workflow to prune old artifacts and completed runs.

---

## What changed
### `_build.yml`
- `upload-artifact`: add `retention-days: 3` (tunable) so the temporary `release-artifacts` bundle auto-expires.

### `release.yml`
- After publishing the GitHub Release, delete the **current run’s** `release-artifacts` using `geekyeggo/delete-artifact@v5`.
- Keeps the pipeline deterministic: release assets are already attached to the Release, so the Actions artifact can be cleaned up.

### `cleanup.yml` (new workflow)
- Runs weekly (`Sun 03:20 UTC`) and supports manual `workflow_dispatch`.
- Deletes repository artifacts older than `ARTIFACT_DAYS` (default 14).
- Deletes **completed** workflow runs older than `RUN_DAYS` (default 45).
- Optional keep-list by name via `KEEP_NAMES` (JSON array).  
- Uses `actions/github-script@v8`; permissions: `actions: write`, `contents: read`.

---

## Why
- Reduce Actions storage usage (and cost).
- Avoid stale bundles lingering after releases.
- Keep the repo’s CI history lean while preserving recent diagnostics.

---

## Configuration knobs
- **Artifact retention on upload:** `_build.yml` → `retention-days: 3`
- **Scheduled cleanup (cleanup.yml env):**
  - `ARTIFACT_DAYS` (default `14`)
  - `RUN_DAYS` (default `45`)
  - `KEEP_NAMES` (default `[]`, e.g. `["release-artifacts"]` to protect names)

Cron schedule can be adjusted as needed.

---

## Testing
- Verified that release publishes correctly with assets, then the `release-artifacts` bundle is removed.
- Dry run cleanup locally by triggering `workflow_dispatch` on `cleanup.yml` and inspecting logs.
- Confirmed no changes to the Release content or tags.

---

## Risks / Mitigations
- **Risk:** Deleting artifacts too aggressively.
  - **Mitigation:** Short retention only for the temporary bundle; release assets remain attached to the GitHub Release.
  - `KEEP_NAMES` and the weekly job’s day thresholds are configurable.
- **Risk:** Cleanup deletes runs you still want.
  - **Mitigation:** Only removes **completed** runs older than `RUN_DAYS` (default 45).

---

## Notes for reviewers
- No secrets added or changed.
- Minimal additional permissions (`actions: write`) for the cleanup workflow.
- Happy to tune the day thresholds or keep-list if you want a different policy.

