### PR TITLE
chore(ci): auto-open draft PR for release/hotfix branches 🧩

### DIFF
--- a/.github/workflows/autocreate-pr.yml
+++ b/.github/workflows/autocreate-pr.yml
@@ -1,0 +1,98 @@
+# .github/workflows/autocreate-pr.yml
+name: PR: Auto-open for release/hotfix branches 🧩
+
+on:
+  push:
+    branches:
+      - 'release/**'
+      - 'hotfix/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open_pr:
+    name: Open draft PR for ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    if: github.event.created == true   # only when the branch is first created
+    steps:
+      - name: 🧮 Derive metadata
+        id: meta
+        run: |
+          branch="${GITHUB_REF_NAME}"
+          case "$branch" in
+            release/*) kind="release"; base="main"; label="release"; emoji="📦" ;;
+            hotfix/*)  kind="hotfix";  base="main"; label="hotfix";  emoji="🩹" ;;
+            *)         kind="other";   base="main"; label="autopr";  emoji="🔧" ;;
+          esac
+          echo "kind=$kind"   >> "$GITHUB_OUTPUT"
+          echo "base=$base"   >> "$GITHUB_OUTPUT"
+          echo "label=$label" >> "$GITHUB_OUTPUT"
+          echo "emoji=$emoji" >> "$GITHUB_OUTPUT"
+
+      - name: 🔎 Check if PR already exists
+        id: find
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const head = context.ref.replace('refs/heads/', '');
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', head: `${owner}:${head}` }
+            );
+            core.setOutput('exists', prs.length > 0 ? 'true' : 'false');
+            if (prs.length > 0) core.info(`Existing PR: #${prs[0].number}`);
+
+      - name: 🧵 Create draft PR (if missing)
+        if: steps.find.outputs.exists != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const head = context.ref.replace('refs/heads/', '');
+            const base = '${{ steps.meta.outputs.base }}';
+            const kind = '${{ steps.meta.outputs.kind }}';
+            const emoji = '${{ steps.meta.outputs.emoji }}';
+
+            // Title like: "📦 release/0.2.34 → main" or "🩹 hotfix/0.2.34.1 → main"
+            const title = `${emoji} ${head} → ${base}`;
+
+            const body = [
+              `## ${title}`,
+              '',
+              '**Checklist**',
+              '- [ ] Version bumped (`Cargo.toml` / Debian changelog)',
+              '- [ ] Changelog updated (git-cliff)',
+              '- [ ] CI green (build, tests, CodeQL)',
+              '',
+              `> Opened automatically when the \`${kind}\` branch was created.`,
+              '',
+              '<sub>Labels, reviewers, and target base are set by convention. Flip to “Ready for review” when autobump & changelog are done.</sub>'
+            ].join('\n');
+
+            const pr = await github.rest.pulls.create({
+              owner, repo, head, base, title, body, draft: true
+            });
+            core.info(`Opened PR #${pr.data.number}`);
+
+      - name: 🏷️ Label the PR
+        if: steps.find.outputs.exists != 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const head = context.ref.replace('refs/heads/', '');
+            const label = '${{ steps.meta.outputs.label }}';
+            const prs = await github.rest.pulls.list({ owner, repo, state: 'open', head: `${owner}:${head}` });
+            if (!prs.data.length) {
+              core.info('No PR found to label.');
+              return;
+            }
+            const number = prs.data[0].number;
+            await github.rest.issues.addLabels({
+              owner, repo, issue_number: number,
+              labels: [label, 'automated']
+            });
+            core.info(`Labeled PR #${number} with [${label}, automated]`);


### PR DESCRIPTION
- Triggers on first push creating a `release/*` or `hotfix/*` branch
- Opens a draft PR to `main` with emoji title and checklist
- Idempotent: skips if a PR already exists for the branch
- Applies labels: `release`/`hotfix` + `automated`