### PR TITLE
Feature/auto tick

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,4 @@
+## Checklist
+- [ ] Version bumped
+- [ ] Changelog updated
+- [ ] CI green

--- a/.github/workflows/_pr-checklist.yml
+++ b/.github/workflows/_pr-checklist.yml
@@ -1,0 +1,99 @@
+name: Reusable — Update PR checklist ☑️
+
+on:
+  workflow_call:
+    inputs:
+      items:
+        description: "Checklist items to tick (one per line, must match PR body text)"
+        type: string
+        required: true
+      comment:
+        description: "Optional comment to post after updating checklist"
+        type: string
+        default: ""
+      remove_label:
+        description: "Optional label to remove after updating checklist"
+        type: string
+        default: ""
+      ready:
+        description: "Set PR draft=false (Ready for review) after update"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update:
+    name: Tick checklist & update PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: ☑️ Update PR checklist
+        uses: actions/github-script@v8
+        with:
+          script: |
+            function escapeRegex(s){return s.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')}
+            const { owner, repo } = context.repo;
+            const head = (context.ref || '').replace('refs/heads/', '');
+            if (!head) { core.info('No branch ref; skipping'); return; }
+
+            // Only operate for release/* or hotfix/*
+            if (!/^release\/|^hotfix\//.test(head)) {
+              core.info(`Branch '${head}' is not release/* or hotfix/*; skipping.`);
+              return;
+            }
+
+            // Find PR
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', head: `${owner}:${head}` }
+            );
+            if (!prs.length) { core.info(`No open PR for ${owner}:${head}`); return; }
+            const pr = prs[0];
+
+            const rawItems = `{{ inputs.items }}`;
+            const items = rawItems.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+
+            let body = pr.body || '';
+            let changed = false;
+
+            for (const label of items){
+              const unchecked = new RegExp(`(^|\\n)\\s*- \\[ \\] \\s*${escapeRegex(label)}(\\s*$)`, 'i');
+              const checked   = new RegExp(`(^|\\n)\\s*- \\[x\\] \\s*${escapeRegex(label)}(\\s*$)`, 'i');
+              if (checked.test(body)) continue;
+              if (unchecked.test(body)) {
+                body = body.replace(unchecked, (_m,p1,p2)=>`${p1}- [x] ${label}${p2}`);
+                changed = true;
+              }
+            }
+
+            if (changed){
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, body });
+              core.info(`Updated checklist on PR #${pr.number}.`);
+            } else {
+              core.info('Checklist already up-to-date or items not found.');
+            }
+
+            const comment = `{{ inputs.comment }}`.trim();
+            if (comment) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body: comment
+              }).catch(() => {});
+            }
+
+            const removeLabel = `{{ inputs.remove_label }}`.trim();
+            if (removeLabel) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: pr.number, name: removeLabel
+              }).catch(() => {});
+            }
+
+            if ({{ inputs.ready }}) {
+              if (pr.draft) {
+                await github.rest.pulls.update({ owner, repo, pull_number: pr.number, draft: false });
+                core.info(`PR #${pr.number} marked Ready for review.`);
+              } else {
+                core.info('PR already Ready for review.');
+              }
+            }

--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -173,7 +173,7 @@ jobs:
             echo "no_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Keep repo CHANGELOG.md in sync (generated on release/hotfix branch) — manual prepend (no --prepend)
+      # Keep repo CHANGELOG.md in sync (generated on release/hotfix branch)
       - name: 📝 Prepend this release to CHANGELOG.md (keep file in repo up to date)
         if: steps.ver.outputs.mode == 'versioned'
         shell: bash
@@ -250,6 +250,17 @@ jobs:
           git commit -m "chore(release): prepare v${{ steps.ver.outputs.value }} [skip ci]"
           git push
 
+      # ✅ Tick boxes right after preparing a versioned release
+      - name: ☑️ PR checklist — version & changelog (versioned)
+        if: steps.ver.outputs.mode == 'versioned'
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            Version bumped
+            Changelog updated
+          comment: "✅ Autobump + changelog complete for v${{ steps.ver.outputs.value }}."
+          remove_label: ""
+
       # ===== MAINTENANCE HOTFIX FLOW (NO VERSION BUMP) =====
       - name: 📝 Debian changelog snapshot (UNRELEASED)
         if: steps.ver.outputs.mode == 'maintenance'
@@ -292,6 +303,7 @@ jobs:
           fi
 
       - name: 🧹 Commit & push maintenance changes
+        if: steps.ver.outputs.mode == 'maintenance'
         shell: bash
         run: |
           set -euo pipefail
@@ -326,7 +338,6 @@ jobs:
               exit 0
             fi
             echo "⛔ Push rejected (attempt ${attempt}) — rebasing onto origin/${BRANCH} and retrying..."
-            # Rebase with autostash; if it fails, abort and retry once more
             if ! git pull --rebase --autostash origin "${BRANCH}"; then
               git rebase --abort || true
             fi
@@ -336,40 +347,34 @@ jobs:
           echo "::error title=Push failed::Could not push after rebasing; another job may still be updating ${BRANCH}."
           exit 1
 
-      - name: ✅ Mark PR “Ready for review”
-        if: success() && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
-        uses: actions/github-script@v8
+      # ✅ Tick box for maintenance changelog
+      - name: ☑️ PR checklist — changelog (maintenance)
+        if: steps.ver.outputs.mode == 'maintenance'
+        uses: ./.github/workflows/_pr-checklist.yml
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const head = context.ref.replace('refs/heads/', '');
+          items: |
+            Changelog updated
+          comment: "🧹 Maintenance changelog snapshot updated."
+          remove_label: ""
 
-            // Look up an open PR for this branch
-            const prs = await github.paginate(
-              github.rest.pulls.list,
-              { owner, repo, state: 'open', head: `${owner}:${head}` }
-            );
-            if (!prs.length) {
-              core.info(`No open PR found for ${owner}:${head}; nothing to do.`);
-              return;
-            }
-            const pr = prs[0];
-            if (!pr.draft) {
-              core.info(`PR #${pr.number} is already Ready for review.`);
-              return;
-            }
+      # ✅ Flip PR Ready (centralized here). Re-ticks (idempotent) and removes 'automated'
+      - name: ✅ Ready for review (versioned)
+        if: success() && steps.ver.outputs.mode == 'versioned' && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            Version bumped
+            Changelog updated
+          comment: "✅ Autobump & changelog complete. Marking PR Ready for review."
+          remove_label: "automated"
+          ready: true
 
-            // Flip draft -> ready
-            await github.rest.pulls.update({
-              owner, repo, pull_number: pr.number, draft: false
-            });
-            core.info(`PR #${pr.number} marked Ready for review.`);
-
-            // Optional niceties: add a comment and adjust labels
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: pr.number,
-              body: "✅ Autobump & changelog complete. CI passed — marking this PR **Ready for review**."
-            }).catch(() => {});
-            await github.rest.issues.removeLabel({
-              owner, repo, issue_number: pr.number, name: 'automated'
-            }).catch(() => {});
+      - name: ✅ Ready for review (maintenance)
+        if: success() && steps.ver.outputs.mode == 'maintenance' && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            Changelog updated
+          comment: "✅ Maintenance prep complete. Marking PR Ready for review."
+          remove_label: "automated"
+          ready: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,15 @@ jobs:
           path: ~/.cache/sccache
           key: sccache-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ needs.gate.outputs.lock_hash }}
 
+      - name: ☑️ PR checklist — CI green
+        if: success() && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            CI green
+          comment: "✅ ${{ github.workflow }} passed."
+          ready: false
+
   package_deb:
     name: 📦 Debian package (push only)
     needs: [gate, build_test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -408,3 +409,12 @@ jobs:
         with:
           path: /root/.cache/sccache
           key: sccache-deb-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ needs.gate.outputs.lock_hash }}
+
+      - name: ☑️ PR checklist — CI green
+        if: success() && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            CI green
+          comment: "✅ ${{ github.workflow }} passed."
+          ready: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: write
   security-events: write
+  pull-requests: write
 
 concurrency:
   group: codeql-${{ github.ref }}
@@ -251,3 +252,12 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:rust;variant=${{ matrix.variant }}"
+
+      - name: ☑️ PR checklist — CI green
+        if: success() && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/'))
+        uses: ./.github/workflows/_pr-checklist.yml
+        with:
+          items: |
+            CI green
+          comment: "✅ ${{ github.workflow }} passed."
+          ready: false

--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -1,0 +1,98 @@
+name: Reusable — Update PR checklist ☑️
+
+on:
+  workflow_call:
+    inputs:
+      items:
+        description: "Checklist items to tick (one per line, must match PR body text)"
+        type: string
+        required: true
+      comment:
+        description: "Optional comment to post after updating checklist"
+        type: string
+        default: ""
+      remove_label:
+        description: "Optional label to remove after updating checklist"
+        type: string
+        default: ""
+      ready:
+        description: "Set PR draft=false (Ready for review) after update"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  update:
+    name: Tick checklist & update PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: ☑️ Update PR checklist
+        uses: actions/github-script@v8
+        with:
+          script: |
+            function escapeRegex(s){return s.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')}
+            const { owner, repo } = context.repo;
+            const head = (context.ref || '').replace('refs/heads/', '');
+            if (!head) { core.info('No branch ref; skipping'); return; }
+
+            // Only operate for release/* or hotfix/* (safety guard); adjust if you like
+            if (!/^release\/|^hotfix\//.test(head)) {
+              core.info(`Branch '${head}' is not release/* or hotfix/*; skipping.`);
+              return;
+            }
+
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', head: `${owner}:${head}` }
+            );
+            if (!prs.length) { core.info(`No open PR for ${owner}:${head}`); return; }
+            const pr = prs[0];
+
+            const rawItems = `{{ inputs.items }}`;
+            const items = rawItems.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+
+            let body = pr.body || '';
+            let changed = false;
+
+            for (const label of items){
+              const unchecked = new RegExp(`(^|\\n)\\s*- \\[ \\] \\s*${escapeRegex(label)}(\\s*$)`, 'i');
+              const checked   = new RegExp(`(^|\\n)\\s*- \\[x\\] \\s*${escapeRegex(label)}(\\s*$)`, 'i');
+              if (checked.test(body)) continue;
+              if (unchecked.test(body)) {
+                body = body.replace(unchecked, (_m,p1,p2)=>`${p1}- [x] ${label}${p2}`);
+                changed = true;
+              }
+            }
+
+            if (changed){
+              await github.rest.pulls.update({ owner, repo, pull_number: pr.number, body });
+              core.info(`Updated checklist on PR #${pr.number}.`);
+            } else {
+              core.info('Checklist already up-to-date or items not found.');
+            }
+
+            const comment = `{{ inputs.comment }}`.trim();
+            if (comment) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number, body: comment
+              }).catch(() => {});
+            }
+
+            const removeLabel = `{{ inputs.remove_label }}`.trim();
+            if (removeLabel) {
+              await github.rest.issues.removeLabel({
+                owner, repo, issue_number: pr.number, name: removeLabel
+              }).catch(() => {});
+            }
+
+            if ({{ inputs.ready }}) {
+              if (pr.draft) {
+                await github.rest.pulls.update({ owner, repo, pull_number: pr.number, draft: false });
+                core.info(`PR #${pr.number} marked Ready for review.`);
+              } else {
+                core.info('PR already Ready for review.');
+              }
+            }


### PR DESCRIPTION
## ✅ PR checklist automation

This PR introduces a reusable workflow `_pr-checklist.yml` to automatically update the checklist in release/hotfix PRs, and wires it into our CI.

### Changes
- **.github/workflows/_pr-checklist.yml**
  - New reusable workflow to tick items in the PR body.
  - Supports adding a comment, removing a label, and flipping draft → ready.
  - Idempotent: if an item is already checked, it skips.

- **ci.yml**
  - Add checklist tick step at the end of the **Build & Test (Linux)** job (covers PRs).
  - Keep existing tick in **package_deb** (covers push builds to `main`/`release/*`).

- **codeql.yml**
  - Ensure checklist tick step runs at the end of the **analyze** job (matrix variants safe; only first one updates).

### Why
- Automates “Version bumped”, “Changelog updated”, and “CI green” checkboxes in release/hotfix PRs.
- Reviewers no longer need to manually update the PR body.
- Ensures the checklist reflects real CI status in near-real time.
- Keeps behaviour simple: first workflow to succeed ticks the box, others no-op.
