### PR TITLE
fix(codeql): Rust doesn’t support `build-mode: manual`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -204,14 +204,14 @@ jobs:
             echo "✅ Cargo.lock up to date."
           fi
 
-      # ---------------- Nightly/Dispatch (deep) — MANUAL BUILD ----------------
-      - name: 🔧 Initialize CodeQL (manual mode)
+      # ------------- Schedule/Dispatch (deep) — CUSTOM BUILD --------------
+      - name: 🔧 Initialize CodeQL (custom build; build-mode none)
         if: github.event_name != 'pull_request'
         uses: github/codeql-action/init@v3
         with:
           languages: rust
           queries: +security-and-quality
-          build-mode: manual
+          build-mode: none   # ← Rust requires 'none' for custom builds
 
       - name: 📦 Pre-fetch dependencies
         if: github.event_name != 'pull_request'
@@ -223,7 +223,7 @@ jobs:
             cargo fetch
           fi
 
-      - name: 🧱 Build Rust (${{ matrix.variant }}) — manual
+      - name: 🧱 Build Rust (${{ matrix.variant }}) — traced by CodeQL
         if: github.event_name != 'pull_request'
         env:
           CARGO_TERM_COLOR: always


### PR DESCRIPTION
switch non-PR runs to `build-mode: none` and keep custom cargo build

- PRs: continue using CodeQL autobuild
- Schedule/dispatch: init with build-mode=none so CodeQL traces our custom `cargo build`
- No functional changes otherwise

## Checklist
- [ ] Version bumped
- [ ] Changelog updated
- [ ] CI green
