### PR TITLE
fix(checklist): gate CI/bump tickers to release/* and hotfix/*; avoid main pushes

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -36,7 +36,6 @@ jobs:
           fetch-tags: true
           persist-credentials: true
 
-      # --- Speedup: cache APT lists + archives between runs (keyed to package list file) ---
       - name: ♻️ Cache APT (lists + archives)
         uses: actions/cache@v4
         with:
@@ -47,18 +46,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-apt-
 
-      # --- Speedup: install Debian tools quickly + use prebuilt git-cliff binary ---
       - name: 🛠️ Install Debian packaging tools & git-cliff (fast)
         shell: bash
         run: |
           set -euo pipefail
           export DEBIAN_FRONTEND=noninteractive
-
-          # 1) Install Debian packaging toolchain from tracked list (quiet + retries; uses cache above)
           sudo apt-get -o Acquire::Retries=3 update -yqq
           sudo apt-get -o Dpkg::Use-Pty=0 install -yqq --no-install-recommends $(tr '\n' ' ' < .github/apt-packages.txt)
-
-          # 2) Install git-cliff via prebuilt release binary (much faster than Cargo)
           if ! command -v git-cliff >/dev/null 2>&1; then
             echo "Installing git-cliff (prebuilt)…"
             tag="$(curl -fsSL https://api.github.com/repos/orhun/git-cliff/releases/latest | jq -r .tag_name)"
@@ -74,8 +68,6 @@ jobs:
             sudo install -m 0755 "${tmpdir}"/git-cliff*/git-cliff /usr/local/bin/git-cliff
             rm -rf "${tmpdir}"
           fi
-
-          # 3) Sanity checks (non-fatal)
           gbp --version || true
           dch --version || true
           git-cliff --version || true
@@ -86,19 +78,16 @@ jobs:
         run: |
           set -euo pipefail
           br="${GITHUB_REF_NAME}"
-          # Versioned release/hotfix: release/x.y[.z][-rcN] or hotfix/x.y[.z][-rcN]
           if [[ "$br" =~ ^(release|hotfix)/([0-9]+(\.[0-9]+){1,2}(-rc[0-9]+)?)$ ]]; then
             v="${BASH_REMATCH[2]}"
             echo "mode=versioned" >> "$GITHUB_OUTPUT"
             echo "value=$v" >> "$GITHUB_OUTPUT"
             echo "Preparing version: $v (from '$br')"
           else
-            # Maintenance hotfix (e.g. hotfix/fix-release)
             echo "mode=maintenance" >> "$GITHUB_OUTPUT"
             echo "Maintenance hotfix detected for '$br' (no version bump)."
           fi
 
-      # ===== VERSIONED FLOW =====
       - name: 📖 Read current Cargo.toml version
         id: cur
         if: steps.ver.outputs.mode == 'versioned'
@@ -132,13 +121,11 @@ jobs:
           prev='${{ steps.prev.outputs.value }}'
           changed=0
 
-          # 1) Bump Cargo.toml if needed
           if [[ "$cur" != "$v" ]]; then
             scripts/set-cargo-version.sh "$v"
             changed=1
           fi
 
-          # 2) Debian changelog with fixed version
           if [[ -n "$prev" ]]; then
             gbp dch --since "$prev" \
                     --new-version "${v}-1" \
@@ -156,10 +143,7 @@ jobs:
           fi
           changed=1
 
-          # 3) Release notes tagged as v$v (collect commits since previous tag) — NO '-u'
           git-cliff --tag "v${v}" -o RELEASE_NOTES.md
-
-          # Guard: don't let "(no notes)" be committed
           if [[ ! -s RELEASE_NOTES.md ]] || grep -qx '(no notes)' RELEASE_NOTES.md; then
             echo "::warning title=Empty release notes::git-cliff produced no entries for v${v}. Skipping staging of RELEASE_NOTES.md."
             git restore --staged --worktree --quiet -- RELEASE_NOTES.md || true
@@ -168,7 +152,6 @@ jobs:
           fi
 
           changed=1
-
           git add -A
           if [[ "$changed" -eq 0 ]]; then
             echo "no_changes=true" >> "$GITHUB_OUTPUT"
@@ -176,36 +159,26 @@ jobs:
             echo "no_changes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Keep repo CHANGELOG.md in sync (generated on release/hotfix branch) — manual prepend (no --prepend)
-      - name: 📝 Prepend this release to CHANGELOG.md (keep file in repo up to date)
+      - name: 📝 Prepend this release to CHANGELOG.md
         if: steps.ver.outputs.mode == 'versioned'
         shell: bash
         run: |
           set -euo pipefail
-          v='${{ steps.ver.outputs.value }}'   # e.g. 0.2.28
+          v='${{ steps.ver.outputs.value }}'
           tag="v${v}"
-
-          # Generate section to a temp file
           tmp="$(mktemp)"
           git-cliff --tag "${tag}" --output "${tmp}"
-
-          # If empty or '(no notes)', do not touch CHANGELOG.md
           if [[ ! -s "${tmp}" ]] || grep -qx '(no notes)' "${tmp}"; then
             echo "::warning title=No changelog section::git-cliff produced no entries for ${tag}; not modifying CHANGELOG.md."
             rm -f "${tmp}"
             exit 0
           fi
-
-          # Ensure file exists with header
           [[ -f CHANGELOG.md ]] || printf "# Changelog\n\n" > CHANGELOG.md
-
-          # Prepend the new section *after* the header line
           new="$(mktemp)"
           awk -v sec="${tmp}" '
             NR==1 { print; print ""; system("cat " sec); next }
             { print }
           ' CHANGELOG.md > "${new}"
-
           mv "${new}" CHANGELOG.md
           rm -f "${tmp}"
           git add CHANGELOG.md || true
@@ -253,7 +226,7 @@ jobs:
           git commit -m "chore(release): prepare v${{ steps.ver.outputs.value }} [skip ci]"
           git push
 
-      # ===== MAINTENANCE HOTFIX FLOW (NO VERSION BUMP) =====
+      # ===== MAINTENANCE HOTFIX FLOW =====
       - name: 📝 Debian changelog snapshot (UNRELEASED)
         if: steps.ver.outputs.mode == 'maintenance'
         shell: bash
@@ -299,52 +272,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-
-          # Figure out branch name even if we're on a detached HEAD
           BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
           if [[ -z "${BRANCH}" || "${BRANCH}" == "HEAD" ]]; then
             BRANCH="$(git rev-parse --abbrev-ref HEAD)"
           fi
-
-          # Only continue if we actually staged something
           if git diff --cached --quiet; then
             echo "No staged maintenance changes; nothing to commit."
             exit 0
           fi
-
           git config user.name  "Lloyd Smart"
           git config user.email "lloydsmart@users.noreply.github.com"
           git commit -m "chore(hotfix): maintenance updates (snapshot changelog, Unreleased notes, lockfile) [skip ci]"
-
-          # Fetch latest remote state to avoid non-fast-forward
           git remote set-url origin "https://github.com/${{ github.repository }}.git"
           git fetch --prune origin +refs/heads/*:refs/remotes/origin/*
-
-          # Ensure we have a local branch tracking the remote
           git checkout -B "${BRANCH}"
-
-          # Try push; if rejected, rebase onto the remote and retry (up to 3 times)
           for attempt in 1 2 3; do
             if git push origin HEAD:"${BRANCH}"; then
               echo "✅ Pushed on attempt ${attempt}"
               exit 0
             fi
             echo "⛔ Push rejected (attempt ${attempt}) — rebasing onto origin/${BRANCH} and retrying..."
-            # Rebase with autostash; if it fails, abort and retry once more
             if ! git pull --rebase --autostash origin "${BRANCH}"; then
               git rebase --abort || true
             fi
             sleep $((attempt * 3))
           done
-
           echo "::error title=Push failed::Could not push after rebasing; another job may still be updating ${BRANCH}."
           exit 1
 
-  # ✅ Tick the “bump & changelog” box when prep succeeds
+  # ✅ Tick the “bump & changelog” box only for release/hotfix contexts
   tick_release_bump_box:
     name: ☑️ PR checklist — Version bump & changelog
     needs: prep
-    if: ${{ needs.prep.result == 'success' }}
+    if: >
+      needs.prep.result == 'success' &&
+      (
+        (github.event_name == 'pull_request' &&
+          (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))) ||
+        (github.event_name == 'push' &&
+          (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')))
+      )
     uses: ./.github/workflows/_tick-release-pr-box.yml
     with:
       box: bump

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,11 +296,18 @@ jobs:
           path: ~/.cache/sccache
           key: sccache-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}-${{ needs.gate.outputs.lock_hash }}
 
-  # ✅ Tick the CI box using the reusable workflow when CI succeeds
+  # ✅ Tick the CI box using the reusable workflow only for release/hotfix contexts
   tick_release_ci_box:
     name: ☑️ PR checklist — CI build & tests passed
     needs: build_test
-    if: ${{ needs.build_test.result == 'success' }}
+    if: >
+      needs.build_test.result == 'success' &&
+      (
+        (github.event_name == 'pull_request' &&
+          (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))) ||
+        (github.event_name == 'push' &&
+          (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')))
+      )
     uses: ./.github/workflows/_tick-release-pr-box.yml
     with:
       box: ci


### PR DESCRIPTION
- CI & autobump tickers now run only on release/hotfix branches (PR/push)
- Prevents “no open PR” errors when jobs run on merge commits to main
- Keeps retry-based PR discovery for race resilience

## Checklist
- [x] Version bumped
- [x] Changelog updated
- [x] CI green
