### PR TITLE
fix(codeql): prevent release checklist update on non-release/hotfix runs 🛡️

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -265,7 +265,7 @@ jobs:
   tick_release_codeql_box:
     name: ☑️ PR checklist — CodeQL scan completed
     needs: analyze
-    if: ${{ needs.analyze.result == 'success' }}
+    if: ${{ needs.analyze.result == 'success' && ((github.event_name == 'pull_request' && (startsWith(github.head_ref, 'release/') || startsWith(github.head_ref, 'hotfix/'))) || (github.event_name != 'pull_request' && (startsWith(github.ref_name, 'release/') || startsWith(github.ref_name, 'hotfix/')))) }}
     uses: ./.github/workflows/_tick-release-pr-box.yml
     with:
       box: codeql


### PR DESCRIPTION
- Added branch-type guard to CodeQL workflow `tick_release_codeql_box` job
- Ensures PR checklist updates only occur on release/* or hotfix/* branches
- Avoids YAML parse errors and false failures during scheduled CodeQL runs

## Checklist
- [ ] Version bumped
- [ ] Changelog updated
- [ ] CI green
