### PR TITLE
fix(clippy): replace sort_by with sort_by_key

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ impl FsState {
         }
 
         // stable sort
-        tmp.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        tmp.sort_by_key(|a| a.name.to_lowercase());
         // assign inode numbers deterministically
         for (i, e) in tmp.iter_mut().enumerate() {
             e.ino = (i as u64) + 2; // root=1


### PR DESCRIPTION
## 📄Summary
Fixes a Clippy lint failure introduced after dependency/toolchain updates.

## Changes
- Replaced `sort_by` comparator with `sort_by_key` for case-insensitive sorting:

  ```rust
  tmp.sort_by_key(|a| a.name.to_lowercase());
Why

Recent Clippy versions flag this pattern as clippy::unnecessary_sort_by, and CI treats warnings as errors (-D warnings), causing builds to fail.

Behaviour

No functional change — sorting remains case-insensitive and stable.

Validation
```bash
cargo fmt
cargo clippy --workspace --all-targets -- -D warnings
cargo test
```

All checks passing locally and in CI.