### PR TITLE
build: upgrade Rust toolchain to 1.88

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,7 @@ impl FsState {
         let dir = &self.args.source_dir;
         let mut tmp: Vec<IndexEntry> = Vec::new();
 
-        for ent in fs::read_dir(dir).with_context(|| format!("reading {:?}", dir))? {
+        for ent in fs::read_dir(dir).with_context(|| format!("reading {dir:?}"))? {
             let ent = ent?;
             let path = ent.path();
 


### PR DESCRIPTION
## Summary

Upgrade project toolchain to Rust 1.88 and align dependencies accordingly.

## Changes

- Add `rust-toolchain.toml` (pins Rust 1.88.0 + components)
- Update dependencies (`cargo update`)
- Fix clippy warnings introduced by newer toolchain (inline format args)
- Ensure CI builds against modern Rust toolchain

## Behaviour

No functional changes intended.

## Validation

- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked --all-features
- Debian package build via CI

All checks passing locally and in CI.

## Notes

This resolves previous build failures caused by dependency MSRV drift (e.g. `time` requiring Rust ≥1.88).