### PR TITLE
feat: add --recursive flag to scan CHD files in subdirectories

### DIFF
--- a/packaging/systemd/chd2iso-fuse@.service
+++ b/packaging/systemd/chd2iso-fuse@.service
@@ -11,6 +11,7 @@ Documentation=man:chd2iso-fuse(1)
 # Optional:
 #   ALLOW_OTHER=yes|no
 #   CD_ALLOW_FORM2=yes|no
+#   RECURSIVE=yes|no
 #   CACHE_HUNKS=#
 #   CACHE_BYTES=#
 #   VERBOSE=yes|no
@@ -29,6 +30,7 @@ ExecStart=/bin/sh -c '\
   cmd="chd2iso-fuse --source \"$$SOURCE\" --mount \"$$TARGET\""; \
   [ "${ALLOW_OTHER:-no}" = yes ] && cmd="$$cmd --allow-other"; \
   [ "${CD_ALLOW_FORM2:-no}" = yes ] && cmd="$$cmd --cd-allow-form2"; \
+  [ "${RECURSIVE:-no}" = yes ] && cmd="$$cmd --recursive"; \
   [ -n "${CACHE_HUNKS:-}" ] && cmd="$$cmd --cache-hunks $$CACHE_HUNKS"; \
   [ -n "${CACHE_BYTES:-}" ] && cmd="$$cmd --cache-bytes $$CACHE_BYTES"; \
   [ "${VERBOSE:-no}" = yes ] && cmd="$$cmd --verbose"; \

--- a/packaging/systemd/ps2.conf.example
+++ b/packaging/systemd/ps2.conf.example
@@ -5,6 +5,7 @@ TARGET=/mnt/retronas/roms/sony/playstation2/iso
 # Optional toggles
 ALLOW_OTHER=yes
 CD_ALLOW_FORM2=no
+RECURSIVE=no
 CACHE_HUNKS=512
 CACHE_BYTES=536870912
 VERBOSE=yes

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,10 @@ struct Args {
     #[arg(long = "cd-allow-form2", default_value_t = false)]
     cd_allow_form2: bool,
 
+    /// Recurse into subdirectories when scanning for *.chd files
+    #[arg(long = "recursive", default_value_t = false)]
+    recursive: bool,
+
     /// Verbose logging
     #[arg(long = "verbose", default_value_t = false)]
     verbose: bool,
@@ -126,35 +130,46 @@ impl FsState {
     }
 
     fn build_index(&mut self) -> Result<()> {
-        let dir = &self.args.source_dir;
+        let dir = self.args.source_dir.clone();
         let mut tmp: Vec<IndexEntry> = Vec::new();
 
-        for ent in fs::read_dir(dir).with_context(|| format!("reading {dir:?}"))? {
-            let ent = ent?;
-            let path = ent.path();
+        let mut dirs: Vec<PathBuf> = vec![dir.clone()];
+        while let Some(current) = dirs.pop() {
+            for ent in fs::read_dir(&current).with_context(|| format!("reading {current:?}"))? {
+                let ent = ent?;
+                let path = ent.path();
+                let ft = ent.file_type()?;
 
-            if path
-                .extension()
-                .and_then(|s| s.to_str())
-                .map(|s| s.eq_ignore_ascii_case("chd"))
-                != Some(true)
-            {
-                continue;
-            }
-
-            match self.build_index_entry(&path) {
-                Ok(Some((name, kind, size))) => {
-                    tmp.push(IndexEntry {
-                        ino: 0,
-                        name,
-                        chd_path: path.clone(),
-                        kind,
-                        iso_size: size,
-                    });
+                if ft.is_dir() {
+                    if self.args.recursive {
+                        dirs.push(path);
+                    }
+                    continue;
                 }
-                Ok(None) => {}
-                Err(e) => {
-                    error!("Skipping {:?}: {}", path, e);
+
+                if path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.eq_ignore_ascii_case("chd"))
+                    != Some(true)
+                {
+                    continue;
+                }
+
+                match self.build_index_entry(&path) {
+                    Ok(Some((name, kind, size))) => {
+                        tmp.push(IndexEntry {
+                            ino: 0,
+                            name,
+                            chd_path: path.clone(),
+                            kind,
+                            iso_size: size,
+                        });
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        error!("Skipping {:?}: {}", path, e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Without this flag `build_index` only scanned the top-level source directory. With `--recursive` it performs a walk through all subdirectories, allowing CHD collections that are organised into sub-folders (e.g. per-letter or per-region) to be served from a single mount point.