### PR TITLE
ci: skip expensive checks for unrelated changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,29 @@ name: CodeQL (Rust) 🦀🔍
 on:
   push:
     branches: [ develop, main ]
+    paths:
+      - 'src/**'
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+      - 'rust-toolchain.toml'
+      - 'debian/**'
+      - '.github/workflows/codeql.yml'
   pull_request:
     branches: [ develop, main ]
+    paths:
+      - 'src/**'
+      - '**/*.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'build.rs'
+      - 'rust-toolchain.toml'
+      - 'debian/**'
+      - '.github/workflows/codeql.yml'
   schedule:
     - cron: "30 3 * * 1"
   workflow_dispatch:
-
 permissions:
   contents: write
   security-events: write
@@ -270,3 +287,4 @@ jobs:
     with:
       box: codeql
     secrets: inherit
+    

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,33 @@
+name: Markdown lint 📝
+
+on:
+  push:
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdown.yml"
+
+  pull_request:
+    paths:
+      - "**/*.md"
+      - ".markdownlint-cli2.yaml"
+      - ".markdownlint-cli2.jsonc"
+      - ".github/workflows/markdown.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  markdownlint:
+    name: Markdown lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@v20
+        with:
+          globs: "**/*.md"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -3,12 +3,23 @@ name: Security checks 🚫🔍 (cargo-deny & cargo-audit)
 on:
   push:
     branches: [ develop, main ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.cargo/audit.toml'
+      - '.github/workflows/security-audit.yml'
   pull_request:
     branches: [ develop, main ]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'deny.toml'
+      - '.cargo/audit.toml'
+      - '.github/workflows/security-audit.yml'
   schedule:
     - cron: "30 3 * * 1"
   workflow_dispatch:
-
 permissions:
   contents: read
   pull-requests: write
@@ -336,3 +347,4 @@ jobs:
         with:
           name: security-reports
           path: reports/*.json
+          


### PR DESCRIPTION
## Summary

- add a dedicated Markdown lint workflow for Markdown changes
- restrict CodeQL runs to Rust, build, packaging, toolchain, and workflow changes
- restrict cargo-deny and cargo-audit runs to dependency and security-policy changes
- preserve scheduled and manually dispatched security scans

## Why

Documentation-only updates were still starting CodeQL and dependency-security jobs even though no Rust code or dependency metadata had changed. This wastes Actions time and produces no useful additional signal.

## Expected behaviour

- Markdown-only changes run Markdown lint
- Rust or build-related changes run CodeQL
- dependency or security-policy changes run cargo-deny and cargo-audit
- scheduled security workflows continue to run regardless of changed paths

## Validation

- workflow YAML preserved with path filters added at trigger level
- branch is one commit ahead of `develop`
- changes are limited to `.github/workflows/codeql.yml`, `.github/workflows/security-audit.yml`, and `.github/workflows/markdown.yml`
