### PR TITLE
docs: establish clean Markdown lint baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,15 +25,17 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/security_exception.md
+++ b/.github/ISSUE_TEMPLATE/security_exception.md
@@ -7,26 +7,31 @@ assignees: []
 ---
 
 ## Advisory
+
 - **ID(s):** <!-- e.g., RUSTSEC-2021-0154 / GHSA-xxxx -->
 - **Crate & version(s):** <!-- e.g., fuser = 0.15.1 -->
 - **Links:** <!-- RustSec URL, GHSA URL, upstream issue/PRs -->
 
 ## Impact assessment
+
 - **Surface in this project:** <!-- where/how the crate is used -->
 - **Input trust:** <!-- untrusted vs trusted inputs -->
 - **Mitigations in place:** <!-- why risk is acceptable now -->
 
 ## Decision
-- **Owner:** @<handle>
+
+- **Owner:** `@handle`
 - **Review by date:** YYYY-MM-DD <!-- set within 3–6 months -->
 - **Exit criteria:** <!-- e.g., upstream release X.Y.Z or migration to crate Z -->
 
 ## Implementation
+
 - **Added to**:
   - `.cargo/audit.toml` ignore list
   - `deny.toml` ignore (with `until`)
 - **CI updated?** <!-- cargo-audit / cargo-deny workflows -->
 
 ## Notes
+
 - Consider alternatives/migrations:
   - <!-- list candidate crates or remedial changes -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
-## Checklist
+# Checklist
+
 - [ ] Version bumped
 - [ ] Changelog updated
 - [ ] CI green

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -25,9 +25,9 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v20
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: "**/*.md"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,8 @@
+config:
+  MD013: false
+
+globs:
+  - "**/*.md"
+  - "!CHANGELOG.md"
+  - "!RELEASE_NOTES.md"
+  - "!artifacts/**"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+# MIT License
 
 Copyright (c) 2025 Lloyd Smart
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](https://img.shields.io/github/license/lloydsmart/chd2iso-fuse)](LICENSE) [![CI](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml/badge.svg)](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/lloydsmart/chd2iso-fuse)](https://github.com/lloydsmart/chd2iso-fuse/releases)
 
-
 **Mount a folder of CHD images and expose them as read-only `.iso`/`.bin` files via FUSE.**  
 Designed for PS2 (OPL over SMB/UDPBD) and NAS setups where you want CHD space savings but still present ISO-style files to clients. Presents **.chd** images as **.iso** (2048-byte Mode1/Mode2-Form1) or **.bin** (2324-byte Mode2-Form2, optional) on the fly.
 
@@ -23,7 +22,8 @@ Designed for PS2 (OPL over SMB/UDPBD) and NAS setups where you want CHD space sa
 - 🌐 **Network-friendly** — Works over **SMB** and **UDPBD** for PS2 OPL game streaming.
 
 > 💡 Typical layout:
-> ```
+>
+> ```text
 > /mnt/retronas/roms/sony/playstation2/chd   # source CHDs (real files)
 > /mnt/retronas/roms/sony/playstation2/iso   # FUSE mountpoint (exposed files)
 > ```
@@ -40,13 +40,14 @@ Designed for PS2 (OPL over SMB/UDPBD) and NAS setups where you want CHD space sa
 
 ---
 
-# Release & Packaging Flow
+## Release & Packaging Flow
 
 This project uses **tag-driven releases**. The Git tag is the single source of truth for the version. On tagged builds, CI updates all versioned artifacts and publishes a GitHub Release with Debian packages.
 
 ## TL;DR
 
 1. Create a tag:
+
    ```bash
    git switch main
    git pull --rebase
@@ -54,6 +55,7 @@ This project uses **tag-driven releases**. The Git tag is the single source of t
    git tag "v$VER" -m "chd2iso-fuse v$VER"
    git push origin "v$VER"
    ```
+
 2. GitHub Actions will:
    - Set `Cargo.toml` → `version = "$VER"` (no cargo-edit; via `scripts/set-cargo-version.sh`)
    - Update `debian/changelog` → `${VER}-1` (via `gbp dch`/`dch`)
@@ -71,6 +73,7 @@ This project uses **tag-driven releases**. The Git tag is the single source of t
 ## Artifacts
 
 The CI publishes:
+
 - `chd2iso-fuse_*_amd64.deb`
 - `chd2iso-fuse-dbgsym_*_amd64.deb`
 - `*.buildinfo`, `*.changes`
@@ -94,7 +97,7 @@ git-cliff --tag "v$VER" -o CHANGELOG.md
 - Just create a new tag (`vX.Y.Z`) and push — CI takes care of the rest.
 - For pre-releases, tags like `v0.5.0-rc.1` are supported; Debian version becomes `0.5.0-rc.1-1`.
 
-## Troubleshooting
+## Release Troubleshooting
 
 - **Mismatch errors**: CI verifies that `Cargo.toml` and `debian/changelog` match the tag. If it fails, check the CI logs for the “Verify … matches tag” steps.
 - **Missing `Cargo.lock`**: the build fails if `Cargo.lock` isn’t committed.
@@ -110,6 +113,7 @@ git-cliff --tag "v$VER" -o CHANGELOG.md
 make
 sudo make install
 ```
+
 Installs to `/usr/local/bin/chd2iso-fuse` by default. Override PREFIX if needed, e.g. `make PREFIX=/usr make install`.
 
 ### Debian / Ubuntu (preferred)
@@ -118,6 +122,7 @@ Installs to `/usr/local/bin/chd2iso-fuse` by default. Override PREFIX if needed,
 make deb
 sudo apt install ../chd2iso-fuse_*.deb
 ```
+
 The `.deb` also installs a mount helper (`/sbin/mount.chd2iso-fuse`) and optional systemd units.
 
 ---
@@ -137,7 +142,7 @@ ls /path/to/iso
 
 ### Common CLI flags
 
-```
+```text
 --source <DIR>        # CHD source directory
 --mount  <DIR>        # FUSE mountpoint
 --allow-other         # allow other users (requires fuse.conf: user_allow_other)
@@ -157,7 +162,8 @@ You can use either the **instance service template** or classic `.mount/.automou
 
 ### Instance service (simple for multiple mounts)
 
-1) Create a config file at `/etc/chd2iso-fuse/<name>.conf`. Example:
+1. Create a config file at `/etc/chd2iso-fuse/<name>.conf`. Example:
+
 ```bash
 SOURCE=/mnt/retronas/roms/sony/playstation2/chd
 TARGET=/mnt/retronas/roms/sony/playstation2/iso
@@ -167,7 +173,9 @@ CACHE_HUNKS=512
 CACHE_BYTES=536870912
 VERBOSE=yes
 ```
-2) Enable:
+
+1. Enable:
+
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now chd2iso-fuse@<name>.service
@@ -176,6 +184,7 @@ sudo systemctl enable --now chd2iso-fuse@<name>.service
 ### Classic `.mount/.automount` (lazy on-demand)
 
 `/etc/systemd/system/mnt-retronas-roms-sony-playstation2-iso.mount`
+
 ```ini
 [Unit]
 Description=Mount CHD→ISO PS2
@@ -194,6 +203,7 @@ WantedBy=multi-user.target
 ```
 
 `/etc/systemd/system/mnt-retronas-roms-sony-playstation2-iso.automount`
+
 ```ini
 [Unit]
 Description=Automount CHD→ISO PS2
@@ -206,6 +216,7 @@ WantedBy=multi-user.target
 ```
 
 Enable:
+
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now mnt-retronas-roms-sony-playstation2-iso.automount
@@ -220,10 +231,13 @@ ls /mnt/retronas/roms/sony/playstation2/iso
 ## fstab (alternative)
 
 With the mount helper installed (`/sbin/mount.chd2iso-fuse`), you can use:
-```
+
+```fstab
 /mnt/retronas/roms/sony/playstation2/chd  /mnt/retronas/roms/sony/playstation2/iso  chd2iso-fuse  allow_other,cache_hunks=512,cache_bytes=536870912,x-systemd.automount,x-systemd.idle-timeout=60s,nofail  0  0
 ```
+
 Then:
+
 ```bash
 sudo systemctl daemon-reload
 sudo mount -a
@@ -234,24 +248,31 @@ sudo mount -a
 ## CHD creation tips (PS2)
 
 - **DVD titles** (most PS2 games): prefer `chdman createdvd` with a raw 2048 ISO:
+
   ```bash
   chdman createdvd -i game.iso -o game.chd
   ```
+
 - **CD titles**: `chdman createcd` from a proper CD dump (`.cue/.bin`):
+
   ```bash
   chdman createcd -i game.cue -o game.chd
   ```
+
 - If your tooling doesn’t have `createdvd`, **fallback**:
+
   ```bash
   chdman createraw -i game.iso -o game.chd
   ```
 
 > Verify a quick slice:
+>
 > ```bash
 > dd if=/path/to/iso/game.iso bs=1M count=16 | md5sum
 > dd if=/path/to/mount/game.iso bs=1M count=16 | md5sum
 > # should match for DVD/2048 (Mode1)
 > ```
+>
 > Form2 `.bin` will NOT match a 2048-byte `.iso` (different payload size).
 
 ---
@@ -309,6 +330,7 @@ match the target distribution (e.g., RetroNAS).
 We publish a `SHA256SUMS` file and a GPG signature `SHA256SUMS.asc` with every release.
 
 1. Import Lloyd’s release key and verify its fingerprint:
+
    ```bash
    # Option A: from a local file
    gpg --import docs/KEYS/lloydsmart-release-public-key.gpg
@@ -322,15 +344,18 @@ We publish a `SHA256SUMS` file and a GPG signature `SHA256SUMS.asc` with every r
    # Check fingerprint
    gpg --fingerprint D91C59CCB2B5AA41
    ```
+
    Expected fingerprint:  
    `28A3 555E 056E 6DFF ED98  84DB D91C 59CC B2B5 AA41`
 
 2. Verify the signature over the checksum file:
+
    ```bash
    gpg --verify SHA256SUMS.asc SHA256SUMS
    ```
 
 3. Verify the files you downloaded:
+
    ```bash
    sha256sum --check SHA256SUMS
    # or on macOS: shasum -a 256 -c SHA256SUMS

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,14 +18,18 @@ The pipeline is powered by GitHub Actions workflows in `.github/workflows`.
 ## Release steps
 
 ### 1. Prepare release branch
+
 - Create a branch from `develop`:
+
   ```bash
   git flow release start x.y.z
   ```
+
 - Update version references (Cargo, Debian changelog) via `autobump.yml` workflow.
 - Push the branch, open a PR into `main`.
 
 ### 2. Merge release branch
+
 - Merge the release PR into `main` (via squash/merge).
 - The `merge.yml` workflow will:
   - Verify version consistency (`_verify-release.yml`)
@@ -34,6 +38,7 @@ The pipeline is powered by GitHub Actions workflows in `.github/workflows`.
   - Open a back-merge PR `main -> develop` (auto-merged if clean)
 
 ### 3. Automated release pipeline
+
 - The `release.yml` workflow will:
   - Validate the tag points to `main`
   - Invoke `_build.yml` in release mode to produce:
@@ -45,6 +50,7 @@ The pipeline is powered by GitHub Actions workflows in `.github/workflows`.
   - Invoke `_release.yml` for optional APT publishing
 
 ### 4. Back-merge
+
 - The `merge.yml` workflow ensures `develop` is kept in sync with `main`:
   - Auto-merges a back-merge PR if it is conflict-free and CI passes
   - Otherwise opens a PR for manual resolution
@@ -54,6 +60,7 @@ The pipeline is powered by GitHub Actions workflows in `.github/workflows`.
 ## Outputs
 
 Each tagged release (`vX.Y.Z`) produces:
+
 - A GitHub Release with:
   - `.deb` package(s)
   - `SHA256SUMS` and detached signature

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,7 @@ We support the latest stable release.
 | <latest | ❌ Not supported   |
 
 ## Reporting a vulnerability
+
 If you believe you’ve found a security issue, please do not open a public issue. Instead, email <lloydsmart@users.noreply.github.com> or use GitHub Security Advisories to contact the maintainers.
 
 ---

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,27 +5,27 @@ and CI automation.
 
 ## Branches
 
--   `develop` --- active development\
--   `main` --- stable, released code\
--   `release/x.y.z` --- temporary branch to prepare a release\
--   `hotfix/x.y.z` --- urgent fix branch cut from `main`
+- `develop` --- active development\
+- `main` --- stable, released code\
+- `release/x.y.z` --- temporary branch to prepare a release\
+- `hotfix/x.y.z` --- urgent fix branch cut from `main`
 
 ------------------------------------------------------------------------
 
 ## TL;DR (10-step quick ref)
 
-1.  `git flow release start x.y.z`\
-2.  `git push -u origin release/x.y.z`\
-3.  Stabilize on `release/x.y.z` (commit fixes).\
-4.  CI **autobump** updates version & changelogs on each push (bot
+1. `git flow release start x.y.z`\
+2. `git push -u origin release/x.y.z`\
+3. Stabilize on `release/x.y.z` (commit fixes).\
+4. CI **autobump** updates version & changelogs on each push (bot
     commits with `[skip ci]`).\
-5.  Open PR: `release/x.y.z` → `main`.\
-6.  Ensure PR CI (fmt, clippy, tests) is green; review the
+5. Open PR: `release/x.y.z` → `main`.\
+6. Ensure PR CI (fmt, clippy, tests) is green; review the
     bump/changelog changes.\
-7.  Merge PR.\
-8.  **On-merge workflow** auto-creates tag `vX.Y.Z` on the merge
+7. Merge PR.\
+8. **On-merge workflow** auto-creates tag `vX.Y.Z` on the merge
     commit.\
-9.  **Release workflow** (on tag) builds, verifies versions, publishes
+9. **Release workflow** (on tag) builds, verifies versions, publishes
     GitHub Release.\
 10. A **back-merge PR** `main → develop` is opened automatically; review
     and merge it.
@@ -38,50 +38,50 @@ Hotfixes follow the same pattern with `hotfix/x.y.z`.
 
 ### 1) CI (Build & Test) --- `ci.yml`
 
--   Runs on PRs and pushes.
--   Checks: `cargo fmt --check`, `clippy -D warnings`,
+- Runs on PRs and pushes.
+- Checks: `cargo fmt --check`, `clippy -D warnings`,
     `cargo test --locked --all-features`.
--   Uses cargo registry/git caches for speed.
--   (Push only, on `main`/`release/*`) builds `.deb` packages and
+- Uses cargo registry/git caches for speed.
+- (Push only, on `main`/`release/*`) builds `.deb` packages and
     uploads as artifacts.
--   Ignores bot commits containing `[skip ci]`.
+- Ignores bot commits containing `[skip ci]`.
 
 ### 2) Release Prep (Autobump) --- `autobump.yml`
 
--   Runs on **pushes to `release/*`** (optionally `hotfix/*`).
--   Derives version from branch name and:
-    -   Updates `Cargo.toml`
-    -   Regenerates `debian/changelog`
-    -   Regenerates `CHANGELOG.md` & `RELEASE_NOTES.md` (via
+- Runs on **pushes to `release/*`** (optionally `hotfix/*`).
+- Derives version from branch name and:
+  - Updates `Cargo.toml`
+  - Regenerates `debian/changelog`
+  - Regenerates `CHANGELOG.md` & `RELEASE_NOTES.md` (via
         `git-cliff`)
--   Commits with `chore(release): prepare vX.Y.Z [skip ci]` (prevents
+- Commits with `chore(release): prepare vX.Y.Z [skip ci]` (prevents
     loops).
 
 ### 3) On merge to main --- `on-merge.yml`
 
--   Runs on **pushes to `main`**.
--   Detects if the push came from a **merged PR** whose source was
+- Runs on **pushes to `main`**.
+- Detects if the push came from a **merged PR** whose source was
     `release/*` or `hotfix/*`.
--   **Verifies versions** using the reusable guard
+- **Verifies versions** using the reusable guard
     (`_verify-release.yml`).
--   **Creates annotated tag** `vX.Y.Z` (no code changes to `main`).
--   **Opens a PR** `main → develop` if `develop` is behind or diverged.
+- **Creates annotated tag** `vX.Y.Z` (no code changes to `main`).
+- **Opens a PR** `main → develop` if `develop` is behind or diverged.
 
 ### 4) Release (on tag) --- `release.yml`
 
--   Runs when **tag `v*`** is pushed.
--   **Guard:** fails early if the tag's commit isn't contained in
+- Runs when **tag `v*`** is pushed.
+- **Guard:** fails early if the tag's commit isn't contained in
     `main`.
--   **Builds & packages**, **verifies versions** (Cargo.toml ↔ Debian ↔
+- **Builds & packages**, **verifies versions** (Cargo.toml ↔ Debian ↔
     binary), then **publishes a GitHub Release** with artifacts and
     notes.
--   (Optional) Can call APT publishing via `_release.yml` when you
+- (Optional) Can call APT publishing via `_release.yml` when you
     enable it.
 
 ### 5) Nightly --- `nightly.yml`
 
--   Builds `develop` nightly (and on manual dispatch).
--   Produces artifacts + a simple manifest.
+- Builds `develop` nightly (and on manual dispatch).
+- Produces artifacts + a simple manifest.
 
 ------------------------------------------------------------------------
 
@@ -96,48 +96,48 @@ git push -u origin release/x.y.z
 
 ### 2) Stabilize on the release branch
 
--   Commit fixes normally.
--   On each push, **Autobump**:
-    -   Ensures `Cargo.toml` version matches `release/x.y.z`
-    -   Updates `debian/changelog`
-    -   Regenerates `CHANGELOG.md` and `RELEASE_NOTES.md`
-    -   Commits with `[skip ci]` so other workflows don't rerun
+- Commit fixes normally.
+- On each push, **Autobump**:
+  - Ensures `Cargo.toml` version matches `release/x.y.z`
+  - Updates `debian/changelog`
+  - Regenerates `CHANGELOG.md` and `RELEASE_NOTES.md`
+  - Commits with `[skip ci]` so other workflows don't rerun
 
 > Tip: If you need to skip CI for a one-off commit, include `[skip ci]`
 > in your own message too.
 
 ### 3) Open a PR to `main`
 
--   Title: `Release x.y.z`.
--   CI must pass (fmt, clippy, tests). Review the version/changelog
+- Title: `Release x.y.z`.
+- CI must pass (fmt, clippy, tests). Review the version/changelog
     diffs as part of the PR.
 
 ### 4) Merge the PR
 
--   Use your usual "Merge" policy.
--   After GitHub completes the merge:
-    -   **On-merge** creates the **annotated tag** `vX.Y.Z` on the merge
+- Use your usual "Merge" policy.
+- After GitHub completes the merge:
+  - **On-merge** creates the **annotated tag** `vX.Y.Z` on the merge
         commit.
-    -   It also opens a **back-merge PR** `main → develop` if needed.
+  - It also opens a **back-merge PR** `main → develop` if needed.
 
 ### 5) Release build & publish
 
--   Tag push automatically triggers **Release**:
-    -   Guard ensures the tag is on `main`.
-    -   Build, package, verify versions.
-    -   Draft + publish the GitHub Release with `.deb`, checksums, and
+- Tag push automatically triggers **Release**:
+  - Guard ensures the tag is on `main`.
+  - Build, package, verify versions.
+  - Draft + publish the GitHub Release with `.deb`, checksums, and
         notes.
 
 ### 6) Back-merge to develop
 
--   A PR `main → develop` is opened for you.
--   Resolve conflicts if any; merge to keep `develop` in sync.
+- A PR `main → develop` is opened for you.
+- Resolve conflicts if any; merge to keep `develop` in sync.
 
 ### 7) Cleanup
 
--   The `release/x.y.z` branch is auto-deleted on merge (remote).
+- The `release/x.y.z` branch is auto-deleted on merge (remote).
 
--   Locally:
+- Locally:
 
     ``` bash
     git fetch --prune
@@ -147,34 +147,34 @@ git push -u origin release/x.y.z
 
 ## Hotfix Flow
 
-1.  `git flow hotfix start x.y.z` (from `main`), push `hotfix/x.y.z`.\
-2.  Stabilize; Autobump keeps version/changelog updated.\
-3.  PR `hotfix/x.y.z` → `main`, merge.\
-4.  On-merge auto-tags `vX.Y.Z`; Release workflow publishes.\
-5.  Back-merge `main → develop` PR is opened; merge it.
+1. `git flow hotfix start x.y.z` (from `main`), push `hotfix/x.y.z`.\
+2. Stabilize; Autobump keeps version/changelog updated.\
+3. PR `hotfix/x.y.z` → `main`, merge.\
+4. On-merge auto-tags `vX.Y.Z`; Release workflow publishes.\
+5. Back-merge `main → develop` PR is opened; merge it.
 
 ------------------------------------------------------------------------
 
 ## Conventions & Safeguards
 
--   **Tag-driven releases:** Only `v*` tags publish. A guard ensures the
+- **Tag-driven releases:** Only `v*` tags publish. A guard ensures the
     tag points to a commit contained in `main`.
--   **No post-merge mutations:** Workflows never push new commits to
+- **No post-merge mutations:** Workflows never push new commits to
     `main`; they only create tags and PRs.
--   **Version guard:** `_verify-release.yml` ensures:
-    -   `Cargo.toml` has **no** `-dev` suffix
-    -   Debian upstream version matches (RCs mapped to `~rcN`)
-    -   `binary --version` == Cargo version
--   **Skip loops:** Bot commits include `[skip ci]`. CI jobs have guards
+- **Version guard:** `_verify-release.yml` ensures:
+  - `Cargo.toml` has **no** `-dev` suffix
+  - Debian upstream version matches (RCs mapped to `~rcN`)
+  - `binary --version` == Cargo version
+- **Skip loops:** Bot commits include `[skip ci]`. CI jobs have guards
     for that phrase.
--   **Required checks:** Only **Build & Test (Linux)** must be green to
+- **Required checks:** Only **Build & Test (Linux)** must be green to
     merge PRs (you may also require CodeQL/security).
 
 ------------------------------------------------------------------------
 
 ## Manual overrides (if needed)
 
--   **Tag locally** (if you prefer or automation is disabled):
+- **Tag locally** (if you prefer or automation is disabled):
 
     ``` bash
     git checkout main
@@ -185,7 +185,7 @@ git push -u origin release/x.y.z
 
     The Release workflow still enforces "tag must be on main".
 
--   **Re-generate notes** on a release branch:
+- **Re-generate notes** on a release branch:
 
     ``` bash
     ./scripts/gen-release-notes.sh
@@ -197,14 +197,14 @@ git push -u origin release/x.y.z
 
 ## Troubleshooting
 
--   **Release didn't run on tag:** Ensure the tag commit is reachable
+- **Release didn't run on tag:** Ensure the tag commit is reachable
     from `main` (guard may have stopped it).
--   **Auto-tag didn't fire:** Confirm the merge was from `release/*` or
+- **Auto-tag didn't fire:** Confirm the merge was from `release/*` or
     `hotfix/*`. Re-run the `on-merge` workflow for that commit, or tag
     manually.
--   **Back-merge PR missing:** It won't open if `develop` isn't
+- **Back-merge PR missing:** It won't open if `develop` isn't
     behind/diverged. Check `on-merge` logs; open a PR manually if
     needed.
--   **Version mismatch errors:** Run the release prep again on the
+- **Version mismatch errors:** Run the release prep again on the
     release branch (push to retrigger Autobump), or fix with the
     provided scripts and commit.


### PR DESCRIPTION
## Summary

- add repository-level markdownlint configuration
- exclude generated changelog and release-artifact Markdown from linting
- normalize formatting across maintained documentation and GitHub templates
- update the Markdown workflow actions to Node.js 24-compatible releases

## Why

The newly added Markdown workflow exposed thousands of existing findings, mostly from generated changelog and release files plus the default 80-character line-length rule. This establishes a practical lint baseline for maintained documentation without producing large, noisy rewrites of generated history.

## Changes

- disable MD013 line-length enforcement
- exclude `CHANGELOG.md`, `RELEASE_NOTES.md`, and `artifacts/**`
- fix heading, list, fence, indentation, and spacing issues in maintained Markdown
- update `actions/checkout` from v4 to v5
- update `DavidAnson/markdownlint-cli2-action` from v20 to v23

## Validation

```text
markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Linting: 11 files
Summary: 0 issues in 0 files
```

The branch is three commits ahead of `develop` and contains documentation, template, lint configuration, and Markdown workflow changes only.