### PR TITLE
ci(security): remove unused RustSec secret fallback

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -129,7 +129,7 @@ jobs:
 
     env:
       # Optional comma-separated allowlist for cargo-audit suppressions
-      ACCEPTED: ${{ vars.RUSTSEC_ACCEPTED_ADVISORIES || secrets.RUSTSEC_ACCEPTED_ADVISORIES || '' }}
+      ACCEPTED: ${{ vars.RUSTSEC_ACCEPTED_ADVISORIES || '' }}
       CARGO_TERM_COLOR: always
 
     steps:


### PR DESCRIPTION
## Summary

Remove the unused secret fallback from the RustSec advisory allowlist configuration.

## Why

RustSec advisory identifiers are not sensitive and are already configured through the repository variable `RUSTSEC_ACCEPTED_ADVISORIES`. Keeping a secret fallback adds unnecessary complexity and causes an avoidable VS Code workflow validation warning.

## Changes

- use only `vars.RUSTSEC_ACCEPTED_ADVISORIES`
- retain an empty-string fallback when the variable is unset