### PR TITLE
chore: relicense project under GPL-3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.7"
 edition = "2021"
 authors = ["Lloyd Smart <lloydsmart@users.noreply.github.com>"]
 description = "FUSE filesystem to mount CHD images as ISO/BIN on the fly"
-license = "MIT"
+license = "GPL-3.0-only"
 repository = "https://github.com/lloydsmart/chd2iso-fuse"
 readme = "README.md"
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,6 +5,6 @@ Copyright (c) 2025 Lloyd Smart
 This project is licensed under the GNU General Public License, version 3.0
 only. The complete license text is available at:
 
-https://www.gnu.org/licenses/gpl-3.0.txt
+[Full GPL-3.0 license text](https://www.gnu.org/licenses/gpl-3.0.txt)
 
 SPDX-License-Identifier: GPL-3.0-only

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,21 +1,10 @@
-# MIT License
+# GNU General Public License v3.0
 
 Copyright (c) 2025 Lloyd Smart
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This project is licensed under the GNU General Public License, version 3.0
+only. The complete license text is available at:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+https://www.gnu.org/licenses/gpl-3.0.txt
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+SPDX-License-Identifier: GPL-3.0-only

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ PRs welcome! Please include a brief description, test notes, and update docs for
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE.md).
+This project is licensed under the [GNU General Public License v3.0](LICENSE.md).
 
 ## Continuous Integration
 

--- a/debian/chd2iso-fuse/usr/share/doc/chd2iso-fuse/copyright
+++ b/debian/chd2iso-fuse/usr/share/doc/chd2iso-fuse/copyright
@@ -1,25 +1,11 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: chd2iso-fuse
-Source: https://github.com/yourname/chd2iso-fuse
+Source: https://github.com/lloydsmart/chd2iso-fuse
 
 Files: *
 Copyright: 2025 Lloyd Smart
-License: MIT
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in all
- copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- SOFTWARE.
+License: GPL-3+
 
+License: GPL-3+
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in /usr/share/common-licenses/GPL-3.

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,23 +4,8 @@ Source: https://github.com/lloydsmart/chd2iso-fuse
 
 Files: *
 Copyright: 2025 Lloyd Smart
-License: MIT
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in
- all copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
+License: GPL-3+
 
-License-File: LICENSE.md
+License: GPL-3+
+ On Debian systems, the complete text of the GNU General Public License
+ version 3 can be found in /usr/share/common-licenses/GPL-3.

--- a/deny.toml
+++ b/deny.toml
@@ -50,6 +50,7 @@ allow = [
 
   # Copyleft (kept allowed so GPL/LGPL crates won’t block CI if introduced)
   "GPL-2.0-or-later",
+  "GPL-3.0-only",
   "GPL-3.0-or-later",
   "LGPL-2.1-or-later",
   "LGPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- Re-license chd2iso-fuse from MIT to GNU GPL v3.0-only.
- Update Cargo metadata, project documentation, and Debian copyright manifests.
- Correct the packaged Debian source URL.

## Validation

- Verified Cargo metadata reports GPL-3.0-only.
- Verified the Git diff has no whitespace errors.