### PR TITLE
chore: ignore Debian copyright files in markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+debian/copyright
+debian/chd2iso-fuse/usr/share/doc/chd2iso-fuse/copyright


### PR DESCRIPTION
Ignore Debian copyright manifests in markdownlint because they use Debian copyright-file syntax rather than Markdown.