### PR TITLE
chore: standardize GPL-3.0 licensing

### DIFF
--- a/Cargo.toml.bak
+++ b/Cargo.toml.bak
@@ -4,7 +4,7 @@ version = "0.3.6"
 edition = "2021"
 authors = ["Lloyd Smart <lloydsmart@users.noreply.github.com>"]
 description = "FUSE filesystem to mount CHD images as ISO/BIN on the fly"
-license = "MIT"
+license = "GPL-3.0-only"
 repository = "https://github.com/lloydsmart/chd2iso-fuse"
 readme = "README.md"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD041 MD029 MD038 MD047 -->
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chd2iso-fuse
 
-[![License](https://img.shields.io/github/license/lloydsmart/chd2iso-fuse)](LICENSE.md) [![CI](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml/badge.svg)](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/lloydsmart/chd2iso-fuse)](https://github.com/lloydsmart/chd2iso-fuse/releases)
+[![License](https://img.shields.io/github/license/lloydsmart/chd2iso-fuse)](LICENSE) [![CI](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml/badge.svg)](https://github.com/lloydsmart/chd2iso-fuse/actions/workflows/ci.yml) [![GitHub release](https://img.shields.io/github/v/release/lloydsmart/chd2iso-fuse)](https://github.com/lloydsmart/chd2iso-fuse/releases)
 
 **Mount a folder of CHD images and expose them as read-only `.iso`/`.bin` files via FUSE.**  
 Designed for PS2 (OPL over SMB/UDPBD) and NAS setups where you want CHD space savings but still present ISO-style files to clients. Presents **.chd** images as **.iso** (2048-byte Mode1/Mode2-Form1) or **.bin** (2324-byte Mode2-Form2, optional) on the fly.
@@ -307,7 +307,7 @@ PRs welcome! Please include a brief description, test notes, and update docs for
 
 ## License
 
-This project is licensed under the [GNU General Public License v3.0](LICENSE.md).
+This project is licensed under the [GNU General Public License v3.0 only](LICENSE).
 
 ## Continuous Integration
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,8 +4,8 @@ Source: https://github.com/lloydsmart/chd2iso-fuse
 
 Files: *
 Copyright: 2025 Lloyd Smart
-License: GPL-3+
+License: GPL-3
 
-License: GPL-3+
+License: GPL-3
  On Debian systems, the complete text of the GNU General Public License
  version 3 can be found in /usr/share/common-licenses/GPL-3.


### PR DESCRIPTION
## What changed

- Standardize the repository on the canonical GNU GPL v3.0 license text in `LICENSE`.
- Align the README badge and license section with the shared repository format.
- Align stale Cargo backup and Debian metadata with `GPL-3.0-only`.

## Why

The three related projects used inconsistent license types, filenames, presentation, and metadata. The extensionless canonical file is both detected correctly by GitHub and outside Markdown linting scope.

## Validation

- `markdownlint-cli2 v0.23.2`: 0 issues
- GitHub license API: `GPL-3.0`
- Commit verified with GPG key `1534542E61DC82D3`